### PR TITLE
Fixed bug where exit code didn't bubble when used with -File option

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -374,6 +374,7 @@ function Invoke-psake {
             
             # Need to return a non-zero DOS exit code so that CI server's (Hudson, TeamCity, etc...) can detect a failed job
             if ((IsChildOfService)) {
+                $host.SetShouldExit($psake.config.exitCode)
                 exit($psake.config.exitCode)
             }
         }


### PR DESCRIPTION
While trying to use TeamCity to run some of my psake tasks using the -File option, the error codes didn't bubble up.  Adding $host.SetShouldExit fixed this issue for me.
