### PR TITLE
Avoided silent errors on loading psake and enabled source information in task error messages.

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -361,7 +361,8 @@ function Invoke-psake {
             $error_message += ("-" * 70) + "`n"
             $error_message += get-variable -scope script | format-table | out-string 
         } else {
-            $error_message = "{0}: An Error Occurred: `n{1}" -f (Get-Date), $_
+            # ($_ | Out-String) gets error messages with source information included. 
+            $error_message = "{0}: An Error Occurred: `n{1}" -f (Get-Date), ($_ | Out-String)
         }
 
         $psake.build_success = $false


### PR DESCRIPTION
## Avoided silent but still added to $Error redundant errors on loading psake.

Remove-Module "[p]sake" is the same as Remove-Module "psake" because the
pattern "[p]sake" matches just "psake" and nothing else. At the same time
Remove-Module does not emit errors when a pattern is resolved to nothing
(unlike in the case with a literal argument). As a result we eliminate the
redundant error silently added to $Error on every first loading of psake.
## Enabled source information in task error messages shown by psake.

Proposed ($_ | Out-String) gets the error message with source information.
In contrast, the original ($_) gets messages without this useful info. Just a
name of a failed task is often not enough in order to locate the problem fast,
for example in a typical case when an error happens in a script called from a
task. Existing verbose error mode is too verbose in many cases when error file
names and line numbers in messages would be enough.
