### PR TITLE
Returning non-zero exit code on build failure is done in psake.cmd instead of in Invoke-Psake

### DIFF
--- a/en-US/psake.psm1-help.xml
+++ b/en-US/psake.psm1-help.xml
@@ -167,7 +167,7 @@ Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x
       <maml:title></maml:title>
       <maml:alert>
 	  <maml:para>---- Exceptions ----</maml:para>
-	  <maml:para>If there is an exception thrown during the running of a build script and the build script was invoked by a windows service then psake will execute the "exit" command (with a default value of "1") which in turn sets the PowerShell $lastexitcode variable otherwise psake will set the '$psake.build_success' variable to $true or $false depending on whether an exception was thrown.</maml:para>
+	  <maml:para>If there is an exception thrown during the running of a build script psake will set the '$psake.build_success' variable to $false. To detect failue outside PowerShell (for example by build server), finish PowerShell process with non-zero exit code when '$psake.build_success' is $false. Calling psake from 'cmd.exe' with 'psake.cmd' will give you that behaviour.</maml:para>
 	  <maml:para></maml:para>
 	  </maml:alert>	  
 	  <maml:alert>

--- a/psake-config.ps1
+++ b/psake-config.ps1
@@ -5,7 +5,6 @@ Defaults
 $config.defaultBuildFileName="default.ps1";
 $config.framework = "3.5";
 $config.taskNameFormat="Executing {0}";
-$config.exitCode="1";
 $config.verboseError=$true;
 $config.coloredOutput = $true;
 $config.modules=(new-object psobject -property @{ autoload=$false })

--- a/psake.cmd
+++ b/psake.cmd
@@ -8,7 +8,7 @@ if '%1'=='?' goto usage
 if '%1'=='/help' goto usage
 if '%1'=='help' goto usage
 
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "& '%DIR%psake.ps1' %*"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "& '%DIR%psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 }"
 
 goto :eof
 :usage

--- a/psake.ps1
+++ b/psake.ps1
@@ -5,33 +5,31 @@
 # Must match parameter definitions for psake.psm1/invoke-psake 
 # otherwise named parameter binding fails
 param(
-  [Parameter(Position=0,Mandatory=0)]
-  [string]$buildFile = 'default.ps1',
-  [Parameter(Position=1,Mandatory=0)]
-  [string[]]$taskList = @(),
-  [Parameter(Position=2,Mandatory=0)]
-  [string]$framework,
-  [Parameter(Position=3,Mandatory=0)]
-  [switch]$docs = $false,
-  [Parameter(Position=4,Mandatory=0)]
-  [System.Collections.Hashtable]$parameters = @{},
-  [Parameter(Position=5, Mandatory=0)]
-  [System.Collections.Hashtable]$properties = @{},
-  [Parameter(Position=6, Mandatory=0)]
-  [string]$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.path),
-  [Parameter(Position=7, Mandatory=0)]
-  [switch]$nologo = $false
+    [Parameter(Position=0,Mandatory=0)]
+    [string]$buildFile = 'default.ps1',
+    [Parameter(Position=1,Mandatory=0)]
+    [string[]]$taskList = @(),
+    [Parameter(Position=2,Mandatory=0)]
+    [string]$framework,
+    [Parameter(Position=3,Mandatory=0)]
+    [switch]$docs = $false,
+    [Parameter(Position=4,Mandatory=0)]
+    [System.Collections.Hashtable]$parameters = @{},
+    [Parameter(Position=5, Mandatory=0)]
+    [System.Collections.Hashtable]$properties = @{},
+    [Parameter(Position=6, Mandatory=0)]
+    [string]$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.path),
+    [Parameter(Position=7, Mandatory=0)]
+    [switch]$nologo = $false
 )
 
 remove-module psake -ea 'SilentlyContinue'
 import-module (join-path $scriptPath psake.psm1)
-if (-not(test-path $buildFile))
-{
+if (-not(test-path $buildFile)) {
     $absoluteBuildFile = (join-path $scriptPath $buildFile)
-	if (test-path $absoluteBuildFile)
-	{
-		$buildFile = $absoluteBuildFile
-	}
+    if (test-path $absoluteBuildFile)	{
+        $buildFile = $absoluteBuildFile
+    }
 } 
+
 invoke-psake $buildFile $taskList $framework $docs $parameters $properties $nologo
-exit $lastexitcode

--- a/specs/writing_psake_variables_should_pass.ps1
+++ b/specs/writing_psake_variables_should_pass.ps1
@@ -28,7 +28,6 @@ task Verify -description "This task verifies psake's variables" {
   Assert ((new-object "System.IO.FileInfo" $config.buildFileName).FullName -eq $psake.build_script_file.FullName) ('$psake.context.peek().config.buildFileName not equal to "{0}"' -f $psake.build_script_file.FullName)
   Assert ($config.framework -eq "3.5") '$psake.context.peek().config.framework not equal to "3.5"'
   Assert ($config.taskNameFormat -eq "Executing {0}") '$psake.context.peek().config.taskNameFormat not equal to "Executing {0}"'
-  Assert ($config.exitCode -eq "1") '$psake.context.peek().config.ExitCode not equal to "1"'
   Assert (!$config.verboseError) '$psake.context.peek().config.verboseError should be $false'
   Assert ($config.coloredOutput) '$psake.context.peek().config.coloredOutput should be $false'
   Assert ($config.modules) '$psake.context.peek().config.modules is $null'


### PR DESCRIPTION
Hi,

I had randomly appearing problem with psake freezing after build failure. After some investigation I found it was because of IsChildOfService function that tried to find parent process and check if it is Windows Service. Unfortunately Windows is not Unix;), and [ParentProcessId](http://msdn.microsoft.com/en-us/library/aa394372.aspx) can point to terminated or completely different process. Probably because that I rarely turn my computer off, sometimes ParentProcessId pointed to some process that point to process that point again to first process, so it caused infinite loop.

Now Invoke-Psake instead of voo-doo to find if it is Windows Service, doesn't do anything special, just sets $psake.build_success, and setting exit code is done in psake.ps1. By the way this also fixed our problem with inability to run psake more than once in one build server run (at least in Hudson).
