### PR TITLE
Fixed issue #28

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -522,7 +522,7 @@ function Configure-BuildEnvironment {
             'x64' {
                 $bitness = 'Framework64'
             }
-            $null {
+            { [string]::IsNullOrEmpty($_) } {
                 $ptrSize = [System.IntPtr]::Size
                 switch ($ptrSize) {
                     4 {


### PR DESCRIPTION
Changing $null to { [string]::IsNullOrEmpty($_) } in bitness detection as "".Substring returns an empty string instead of $null.
