### PR TITLE
Allow scriptblock execution for initialization step

### DIFF
--- a/psake-buildTester.ps1
+++ b/psake-buildTester.ps1
@@ -40,8 +40,7 @@ function runBuilds()
 	{		
 		$testResult = "" | select Name, Result
 		$testResult.Name = $buildFile.Name
-
-		invoke-psake $buildFile.FullName -Parameters @{'p1'='v1'; 'p2'='v2'} -Properties @{'x'='1'; 'y'='2'} | Out-Null			
+		invoke-psake $buildFile.FullName -Parameters @{'p1'='v1'; 'p2'='v2'} -Properties @{'x'='1'; 'y'='2'} -Initialization { if(!$container) { $container = @{}; } $container.bar = "bar"; $container.baz = "baz"; $bar = 2; $baz = 3 } | Out-Null
 		$testResult.Result = (getResult $buildFile.Name $psake.build_success)
 		$testResults += $testResult
 		if ($testResult.Result -eq "Passed")

--- a/psake.ps1
+++ b/psake.ps1
@@ -18,10 +18,13 @@ param(
     [Parameter(Position=5, Mandatory=0)]
     [System.Collections.Hashtable]$properties = @{},
     [Parameter(Position=6, Mandatory=0)]
-    [switch]$nologo = $false,
+    [alias("init")]
+    [scriptblock]$initialization = {},
     [Parameter(Position=7, Mandatory=0)]
-    [switch]$help = $false,
+    [switch]$nologo = $false,
     [Parameter(Position=8, Mandatory=0)]
+    [switch]$help = $false,
+    [Parameter(Position=9, Mandatory=0)]
     [string]$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.path)
 )
 
@@ -35,9 +38,9 @@ if ($help) {
 
 if (-not(test-path $buildFile)) {
     $absoluteBuildFile = (join-path $scriptPath $buildFile)
-    if (test-path $absoluteBuildFile)	{
+    if (test-path $absoluteBuildFile) {
         $buildFile = $absoluteBuildFile
     }
 } 
 
-invoke-psake $buildFile $taskList $framework $docs $parameters $properties $nologo
+invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo

--- a/psake.psm1
+++ b/psake.psm1
@@ -272,7 +272,8 @@ function Invoke-psake {
         [Parameter(Position = 3, Mandatory = 0)][switch] $docs = $false, 
         [Parameter(Position = 4, Mandatory = 0)][hashtable] $parameters = @{}, 
         [Parameter(Position = 5, Mandatory = 0)][hashtable] $properties = @{},
-        [Parameter(Position = 6, Mandatory = 0)][switch] $nologo = $false
+        [Parameter(Position = 6, Mandatory = 0)][alias("init")][scriptblock] $initialization = {},
+        [Parameter(Position = 7, Mandatory = 0)][switch] $nologo = $false
     )
     try {
         if (-not $nologo) {
@@ -357,6 +358,10 @@ function Invoke-psake {
                 set-item -path "variable:\$key" -value $properties.$key | out-null
             }
         }
+
+        # Simple dot sourcing will not work. We have to force the script block into our
+        # module's scope in order to initialize variables properly.
+        . $MyInvocation.MyCommand.Module $initialization
 
         # Execute the list of tasks or the default task
         if ($taskList) {

--- a/specs/using_initialization_block_should_pass.ps1
+++ b/specs/using_initialization_block_should_pass.ps1
@@ -1,0 +1,23 @@
+﻿properties {
+	$container = @{}
+	$container.foo = "foo"
+	$container.bar = $null
+	$foo = 1
+	$bar = 1
+}
+
+task default -depends TestInit
+
+task TestInit {
+  # values are:
+  # 1: original
+  # 2: overide
+  # 3: new
+  
+  Assert ($container.foo -eq "foo") "$container.foo should be foo"
+  Assert ($container.bar -eq "bar") "$container.bar should be bar"
+  Assert ($container.baz -eq "baz") "$container.baz should be baz"
+  Assert ($foo -eq 1) "$foo should be 1"
+  Assert ($bar -eq 2) "$bar should be 2"
+  Assert ($baz -eq 3) "$baz should be 3"
+}


### PR DESCRIPTION
The patch includes an integration test and adds the -init / -initialization option to the psake command line adding the ability to pass a scriptblock that will run after the parameters and properties blocks.

The parameters and properties blocks only allow name/value pairs for initialization. This update allows us to override complex types.

I prefer to use variables that are built off of hashtables like the psake context to create a cleaner DSL. With this patch I can now override the following example 'variables':

properties {
  $msbuild = @{}
  $msbuild.logfilename = "MSBuildOutput.txt"
  $msbuild.logfilepath = $build.dir
  $msbuild.build_in_parralel = $true
  $msbuild.logger = "FileLogger,Microsoft.Build.Engine"
  $msbuild.platform = "Any CPU"
}

I think that this improves readability and allows us to group variables by intent.

example:
invoke-psake \build.ps1 -Initialization {
  if(!$container) { $container = @{}; } # this is needed for each container variable you with to use.
  $container.bar = "bar" # complex 'namespaced' variable override
  $container.baz = "baz" # adds a new 'namespaced' value
  $bar = 2 # simple value override
  $baz = 3  # new simple value
}
