### PR TITLE
Fixed exit code being swallowed by the psake.cmd script.

### DIFF
--- a/psake.cmd
+++ b/psake.cmd
@@ -5,7 +5,7 @@ if '%1'=='-help' goto help
 if '%1'=='-h' goto help
 
 powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }"
-goto :eof
+exit /B %errorlevel%
 
 :help
 powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' -help"


### PR DESCRIPTION
The exit code from PowerShell was not being used as the exit code from the psake.cmd script. This update fixes that so that the CMD script will exit with the same code that the PowerShell script exited with.
