### PR TITLE
ChocolateyInstall.ps1 should use a known environment variable instead of a hard coded path

### DIFF
--- a/nuget/tools/chocolateyInstall.ps1
+++ b/nuget/tools/chocolateyInstall.ps1
@@ -1,14 +1,19 @@
-$nugetPath = 'C:\NuGet'
-$nugetExePath = Join-Path $nuGetPath 'bin'
-$packageBatchFileName = Join-Path $nugetExePath "psake.bat"
+try { 
+  $nugetPath = $env:ChocolateyInstall
+  $nugetExePath = Join-Path $nuGetPath 'bin'
+  $packageBatchFileName = Join-Path $nugetExePath "psake.bat"
 
-$psakeDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
-#$path = ($psakeDir | Split-Path | Join-Path -ChildPath  'psake.cmd')
-$path = Join-Path $psakeDir  'psake.cmd'
-Write-Host "Adding $packageBatchFileName and pointing to $path"
-"@echo off
-""$path"" %*" | Out-File $packageBatchFileName -encoding ASCII 
+  $psakeDir = (Split-Path -parent $MyInvocation.MyCommand.Definition)
+  #$path = ($psakeDir | Split-Path | Join-Path -ChildPath  'psake.cmd')
+  $path = Join-Path $psakeDir  'psake.cmd'
+  Write-Host "Adding $packageBatchFileName and pointing to $path"
+  "@echo off
+  ""$path"" %*" | Out-File $packageBatchFileName -encoding ASCII 
 
+  write-host "PSake is now ready. You can type 'psake' from any command line at any path. Get started by typing 'psake /?'"
 
-write-host "PSake is now ready. You can type 'psake' from any command line at any path. Get started by typing 'psake /?'"
-Start-Sleep 6
+  Write-ChocolateySuccess 'psake'
+} catch {
+  Write-ChocolateyFailure 'psake' "$($_.Exception.Message)"
+  throw 
+}


### PR DESCRIPTION
This fixes errors with the current package when attempting to install from chocolatey. Also wrapped in a try/catch and removed the 6 second sleep time that is no longer necessary.
