### PR TITLE
Add alias to task documentation and format as list to allow for wide descriptions

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -616,11 +616,12 @@ function Write-Documentation {
         $task = $currentContext.tasks.$_
         new-object PSObject -property @{
             Name = $task.Name;
+            Alias = $task.Alias;
             Description = $task.Description;
             "Depends On" = $task.DependsOn -join ", "
             Default = if ($defaultTaskDependencies -contains $task.Name) { $true }
         }
-    } | sort 'Name' | format-table -autoSize -property Name,Description,"Depends On",Default
+    } | sort 'Name' | format-list -property Name,Alias,Description,"Depends On",Default
 }
 
 function Write-TaskTimeSummary($invokePsakeDuration) {


### PR DESCRIPTION
Add alias to task documentation and format as list to allow for wide descriptions. I can understand if others might want to keep the formatting as a table but I find that more often than not the descriptions stretch beyond the terminal in the table format. The list formatting is also more in line with the native powershell parameter help formatting.
