### PR TITLE
Turkish i problem

### DIFF
--- a/psake.ps1
+++ b/psake.ps1
@@ -28,6 +28,11 @@ param(
     [string]$scriptPath = $(Split-Path -parent $MyInvocation.MyCommand.path)
 )
 
+$currentThread = [System.Threading.Thread]::CurrentThread
+$invariantCulture = [System.Globalization.CultureInfo]::InvariantCulture
+$currentThread.CurrentCulture = $invariantCulture
+$currentThread.CurrentUICulture = $invariantCulture
+
 # '[p]sake' is the same as 'psake' but $Error is not polluted
 remove-module [p]sake
 import-module (join-path $scriptPath psake.psm1)


### PR DESCRIPTION
Hi, calling powershell functions which start with i throwing error in Turkish culture. You can repro problem easily by setting current culture to Turkish before calling import-module in psake.ps1. 

[System.Threading.Thread]::CurrentThread.CurrentCulture = "tr-Tr"

This commit fixes it by setting current culture to invariant.
