### PR TITLE
Fix for psake.ps1 and psake.cmd errorlevel/lastexitcode based on build_success

### DIFF
--- a/psake.cmd
+++ b/psake.cmd
@@ -4,7 +4,10 @@ if '%1'=='/?' goto help
 if '%1'=='-help' goto help
 if '%1'=='-h' goto help
 
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*"
+if errorlevel 1 (
+    exit /b 1
+)
 goto :eof
 
 :help

--- a/psake.ps1
+++ b/psake.ps1
@@ -44,3 +44,6 @@ if (-not(test-path $buildFile)) {
 } 
 
 invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo
+if (-not($psake.build_success)) {
+    exit 1
+}


### PR DESCRIPTION
If I run psake.ps1 on my continuous integration server and it doesn't result in a non-zero errorlevel somebody's going to have a false-positive at some point...  In a basic test, ".\build.ps1 idontexist" the $lastexitcode was still zero.  Similarly, running ".\build.cmd idontexist" is the same.

It looks like psake.psm1 is catching all throws, spitting them out in red, and setting $psake.build_success = false.  This tells me that the errorlevel/$lastexitcode should be based on $psake.build_success or is an uncaught exception that should bubble out.

Hope you find this useful to the community.
