### PR TITLE
Ensure TabExpansion function exists before rename.

### DIFF
--- a/tabexpansion/Readme.PsakeTab.txt
+++ b/tabexpansion/Readme.PsakeTab.txt
@@ -12,7 +12,7 @@ Push-Location (Split-Path -Path $MyInvocation.MyCommand.Definition -Parent)
 . ./PsakeTabExpansion.ps1
 Pop-Location
 
-if(-not (Test-Path Function:\DefaultTabExpansion)) {
+if((Test-Path Function:\TabExpansion) -and (-not (Test-Path Function:\DefaultTabExpansion))) {
     Rename-Item Function:\TabExpansion DefaultTabExpansion
 }
 


### PR DESCRIPTION
Prevents an error in environment where there is no initial TabExpansion function defined. 
This seems strange, but that's what started occurring on my system. 
