### PR TITLE
Fix for setting $config.moduleScope to "global"

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -772,6 +772,7 @@ $psake.config_default = new-object psobject -property @{
     verboseError = $false;
     coloredOutput = $true;
     modules = $null;
+    moduleScope = "";
 } # contains default configuration, can be overriden in psake-config.ps1 in directory with psake.psm1 or in directory with current build script
 
 $psake.build_success = $false # indicates that the current build was successful


### PR DESCRIPTION
This is related to my comment (https://github.com/psake/psake/pull/42#issuecomment-16796150) to pull request #42 and fixes it.
