### PR TITLE
powershell hangs when calling from bat file with redirected stdin

### DIFF
--- a/psake.cmd
+++ b/psake.cmd
@@ -4,7 +4,7 @@ if '%1'=='/?' goto help
 if '%1'=='-help' goto help
 if '%1'=='-h' goto help
 
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }"
+powershell -inputformat none -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }"
 exit /B %errorlevel%
 
 :help


### PR DESCRIPTION
The build software we're using at work got upgraded this monday. After that, all all builds hanged on completion; powershell never exited.

Adding '-inputformat none' solved the issue, pending a software update from our build server supplier.

More information is available on these links
http://connect.microsoft.com/PowerShell/feedback/details/572313/powershell-exe-can-hang-if-stdin-is-redirected
http://stackoverflow.com/questions/4238192/running-powershell-from-msdeploy-runcommand-does-not-exit/4239192#4239192
