### PR TITLE
Fixing a logical or problem with default tasks

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -316,7 +316,7 @@ function Invoke-psake {
 
         # If the default.ps1 file exists and the given "buildfile" isn 't found assume that the given
         # $buildFile is actually the target Tasks to execute in the default.ps1 script.
-        if (($buildFile -or !(test-path $buildFile -pathType Leaf)) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
+        if (([string]::IsNullOrWhiteSpace($buildFile) -or !(test-path $buildFile -pathType Leaf)) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
             $taskList = $buildFile.Split(', ')
             $buildFile = $psake.config_default.buildFileName
         }


### PR DESCRIPTION
This should resolve the issue and tests correctly

I have a default.ps1 file and when calling psake ( alias ) without a task I get a path null error below. When I call with a task it works. After debugging this I found a -and that should be a -or. I'm submitting the issue and a pull request for this.

PS C:----\Source> psake
psake version 4.3.0
Copyright (c) 2010 James Kovacs

Error: 12/13/2013 11:36:47 AM:
At C:\Users\dliles\Documents\WindowsPowerShell\Modules\PSake\PSake.psm1:325 char:27 + Assert (test-path $buildF
ile -pathType Leaf) ($msgs.error_build_file_not ... + ~~~~~~~~~~ [<<==>>] Exception: Cannot b
ind argument to parameter 'Path' because it is an empty string.
PS C:----\Source>

Code that is incorrect
if ($buildFile -and !(test-path $buildFile -pathType Leaf) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
$taskList = $buildFile.Split(', ')
$buildFile = $psake.config_default.buildFileName
}

```
# Execute the build file to set up the tasks and defaults
Assert (test-path $buildFile -pathType Leaf) ($msgs.error_build_file_not_found -f $buildFile)
```

Should Be
if (($buildFile -or !(test-path $buildFile -pathType Leaf)) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
$taskList = $buildFile.Split(', ')
$buildFile = $psake.config_default.buildFileName
}

```
# Execute the build file to set up the tasks and defaults
Assert (test-path $buildFile -pathType Leaf) ($msgs.error_build_file_not_found -f $buildFile)
```
