### PR TITLE
trying to get Exec to behave like it used to

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -142,8 +142,12 @@ function Exec
     $tryCount = 1
 
     do {
-        try { 
+        try {
+            $lastexitcode = 0 
             & $cmd
+            if ($lastexitcode -ne 0) {
+                throw ("Exec: " + $errorMessage)
+            }
             break
         }
         catch [Exception]
@@ -316,7 +320,7 @@ function Invoke-psake {
 
         # If the default.ps1 file exists and the given "buildfile" isn 't found assume that the given
         # $buildFile is actually the target Tasks to execute in the default.ps1 script.
-        if (([string]::IsNullOrWhiteSpace($buildFile) -or !(test-path $buildFile -pathType Leaf)) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
+        if ($buildFile -and !(test-path $buildFile -pathType Leaf) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
             $taskList = $buildFile.Split(', ')
             $buildFile = $psake.config_default.buildFileName
         }

--- a/specs/nonzero_lastexitcode_should_throw_should_fail.ps1
+++ b/specs/nonzero_lastexitcode_should_throw_should_fail.ps1
@@ -1,0 +1,5 @@
+task default -depends MSBuildWithError
+
+task MSBuildWithError {
+  exec { msbuild ThisFileDoesNotExist.sln }
+}

--- a/specs/running_aspnet_compiler_under_dotNet35_should_pass.ps1
+++ b/specs/running_aspnet_compiler_under_dotNet35_should_pass.ps1
@@ -3,8 +3,12 @@ $framework = '3.5'
 task default -depends AspNetCompiler
 
 task AspNetCompiler {
-  aspnet_compiler
-  if ($LastExitCode -ne 1) {
-    throw 'Error: Could not execute aspnet_compiler'
+  try {
+    aspnet_compiler
+  }
+  catch [Exception]{
+    if ($LastExitCode -ne 1) {
+      throw 'Error: Could not execute aspnet_compiler'
+    }
   }
 }


### PR DESCRIPTION
This pull request combines the two behaviors for Exec. It still allows retries while preserving the old behavior of throwing if the command Exec'd sets $lastexitcode.

I've also added a test spec to test the Exec behavior as well as modified a spec so it will still validate what it was testing before while working with the new behavior.

The new spec (nonzero_lastexitcode_should_throw_should_fail.ps1) behaves as I would expect when run in isolation, but it doesn't appear to work when run from psake-buildTester.ps1.
