### PR TITLE
Alphabetized the list of contributors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,9 +48,9 @@ Also check out the **[psake-contrib](http://github.com/psake/psake-contrib)** pr
 Many thanks for contributions to psake are due (in alphabetical order):
 
 * candland
-* Staxmanade
 * lanwin
 * smbecker
+* Staxmanade
 * stej
 
 ## License


### PR DESCRIPTION
I thought it was funny that it specifically says "in alphabetical order", but then it wasn't actually alphabetical. So, now it is.
