### PR TITLE
#66 - Revert -docs back to table format and add -detailedDocs

### DIFF
--- a/psake.ps1
+++ b/psake.ps1
@@ -25,7 +25,9 @@ param(
     [Parameter(Position=8, Mandatory=0)]
     [switch]$help = $false,
     [Parameter(Position=9, Mandatory=0)]
-    [string]$scriptPath
+    [string]$scriptPath,
+    [Parameter(Position=10,Mandatory=0)]
+    [switch]$detailedDocs = $false
 )
 
 # setting $scriptPath here, not as default argument, to support calling as "powershell -File psake.ps1"
@@ -48,4 +50,4 @@ if ($buildPath -and (-not(test-path $buildFile))) {
     }
 } 
 
-Invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo
+Invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo $detailedDocs


### PR DESCRIPTION
- It turns out the previous -docs implementation was reverted some months ago in the following commit https://github.com/psake/psake/commit/b1d8518c8847f81e54c379dc3445856f31f00a8c to use the original and more compact format-table for output, this is part of the most recent release (v4.3.2).
- This commit adds the -detailedDocs parameter to use format-list for more detailed and list formatted documentation as requested in issue #66 
