### PR TITLE
Fixes error if VS 14.0 installed and VS 12.0 is not

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -623,7 +623,11 @@ function ConfigureBuildEnvironment {
     }
     $frameworkDirs = @()
     if ($buildToolsVersions -ne $null) {
-        $frameworkDirs = @($buildToolsVersions | foreach { (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$_" -Name $buildToolsKey).$buildToolsKey })
+        foreach($ver in $buildToolsVersions) {
+            if (Test-Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver") {
+                $frameworkDirs += (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver" -Name $buildToolsKey).$buildToolsKey
+            }
+        }
     }
     $frameworkDirs = $frameworkDirs + @($versions | foreach { "$env:windir\Microsoft.NET\$bitness\$_\" })
 


### PR DESCRIPTION
Existing code throws exception if  Visual Studio 14.0 is installed and
Visual Studio 12.0 is not. Changed to verify key exists before
retrieving it.
