### PR TITLE
Add support for 4.5.2

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -580,7 +580,7 @@ function ConfigureBuildEnvironment {
         '4.0' {
             $versions = @('v4.0.30319')
         }
-        '4.5.1' {
+        {($_ -eq '4.5.1') -or ($_ -eq '4.5.2')} {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0', '12.0')
         }


### PR DESCRIPTION
The version paths have not changed between .NET 4.5.2 and 4.5.1. 

This change effectively treats 4.5.2 as 4.5.1.