### PR TITLE
Added support for .net 4.6

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -584,6 +584,11 @@ function ConfigureBuildEnvironment {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0', '12.0')
         }
+        '4.6' {
+            $versions = @('v4.0.30319')
+            $buildToolsVersions = @('14.0')
+        }
+
         default {
             throw ($msgs.error_unknown_framework -f $versionPart, $framework)
         }

--- a/specs/dotNet4.6_should_pass.ps1
+++ b/specs/dotNet4.6_should_pass.ps1
@@ -1,0 +1,8 @@
+Framework "4.6"
+
+task default -depends MsBuild
+
+task MsBuild {
+  $output = &msbuild /version 2>&1
+  Assert ($output -NotLike "14.0") '$output should contain 14.0'
+}


### PR DESCRIPTION
On a clean install of VS2015, there's no MsBuild version 12.