### PR TITLE
Adding an example for a parallel task

### DIFF
--- a/examples/paralleltasks.ps1
+++ b/examples/paralleltasks.ps1
@@ -1,0 +1,20 @@
+Task ParallelTask1 {
+    "ParallelTask1"
+}
+
+Task ParallelTask2 {
+    "ParallelTask2"
+}
+
+Task ParallelNested1andNested2 {
+    $jobArray = @()
+    @("ParallelTask1", "ParallelTask2") | ForEach-Object {
+        $jobArray += Start-Job { 
+            param($scriptFile, $taskName)
+                Invoke-psake $scriptFile -taskList $taskName
+            } -ArgumentList $psake.build_script_file.FullName, $_ 
+    }
+    Wait-Job $jobArray | Receive-Job
+}
+
+Task default -depends ParallelNested1andNested2


### PR DESCRIPTION
just added an example script that shows how someone might do parallel tasks without too much headache. this doesn't deal with exceptions just yet but i think it's a great start. i can easily see something like this making it's way into the `Invoke-Task` using some `parallelDepends` argument/parameter. This can also be simply modified to point to a different script for the subsequent `Invoke-psake` calls.