### PR TITLE
Added -structuredDocs option to Invoke-psake.

### DIFF
--- a/en-US/psake.psm1-help.xml
+++ b/en-US/psake.psm1-help.xml
@@ -47,6 +47,14 @@
           <maml:name>nologo</maml:name>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         </command:parameter>
+	<command:parameter require="false" variableLength="false" globbing="false" pipelineInput="false" postion="0">
+          <maml:name>detailedDocs</maml:name>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        </command:parameter>
+	<command:parameter require="false" variableLength="false" globbing="false" pipelineInput="false" postion="0">
+          <maml:name>structuredDocs</maml:name>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        </command:parameter>
         <command:parameter require="false" variableLength="false" globbing="false" pipelineInput="false" postion="0">
           <maml:name>notr</maml:name>
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
@@ -94,7 +102,7 @@ Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="3">
         <maml:name>docs</maml:name>
         <maml:description>
-            <maml:para>Prints a list of tasks and their descriptions</maml:para>
+            <maml:para>Prints a list of tasks and their descriptions.</maml:para>
           </maml:description>
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
@@ -128,7 +136,7 @@ Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x
         </dev:type>
         <dev:defaultValue />
       </command:parameter>
-      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="6">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="7">
         <maml:name>nologo</maml:name>
          <maml:description>
             <maml:para>Do not display the startup banner and copyright message.</maml:para>
@@ -140,7 +148,31 @@ Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x
         </dev:type>
         <dev:defaultValue />
       </command:parameter>
-      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="6">
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="8">
+        <maml:name>detailedDocs</maml:name>
+        <maml:description>
+            <maml:para>Prints a detailed list of tasks and their descriptions.</maml:para>
+          </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue />
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="9">
+        <maml:name>structuredDocs</maml:name>
+        <maml:description>
+            <maml:para>Returns objects that represent the different tasks contained in the script.</maml:para>
+          </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue />
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="false (ByValue)" position="10">
         <maml:name>notr</maml:name>
          <maml:description>
             <maml:para>Do not display the time report.</maml:para>

--- a/specs/detailedDocs_should_pass.ps1
+++ b/specs/detailedDocs_should_pass.ps1
@@ -1,0 +1,52 @@
+
+Task default -depends CheckDetailedDocs
+
+Task CheckDetailedDocs {
+    $doc = Invoke-psake .\nested\docs.ps1 -detailedDocs -nologo | Out-String
+
+    $expectedDoc = @"
+
+
+Name        : Compile
+Alias       : 
+Description : 
+Depends On  : CompileSolutionA, CompileSolutionB
+Default     : True
+
+Name        : CompileSolutionA
+Alias       : 
+Description : Compiles solution A
+Depends On  : 
+Default     : 
+
+Name        : CompileSolutionB
+Alias       : 
+Description : 
+Depends On  : 
+Default     : 
+
+Name        : IntegrationTests
+Alias       : 
+Description : 
+Depends On  : 
+Default     : 
+
+Name        : Test
+Alias       : 
+Description : 
+Depends On  : UnitTests, IntegrationTests
+Default     : True
+
+Name        : UnitTests
+Alias       : ut
+Description : 
+Depends On  : 
+Default     : 
+
+
+
+
+"@
+    Assert ($doc -eq $expectedDoc) "Unexpected simple doc: $doc"
+
+}

--- a/specs/docs_should_pass.ps1
+++ b/specs/docs_should_pass.ps1
@@ -1,0 +1,23 @@
+
+Task default -depends CheckDocs
+
+Task CheckDocs {
+
+    $doc = Invoke-psake .\nested\docs.ps1 -docs -nologo | Out-String
+
+    $expectedDoc = @"
+
+Name             Alias Depends On                         Default Description        
+----             ----- ----------                         ------- -----------        
+Compile                CompileSolutionA, CompileSolutionB    True                    
+CompileSolutionA                                                  Compiles solution A
+CompileSolutionB                                                                     
+IntegrationTests                                                                     
+Test                   UnitTests, IntegrationTests           True                    
+UnitTests        ut                                                                  
+
+
+
+"@
+    Assert ($doc -eq $expectedDoc) "Unexpected simple doc: $doc"
+}

--- a/specs/nested/docs.ps1
+++ b/specs/nested/docs.ps1
@@ -1,0 +1,14 @@
+
+Task default -depends Compile,Test
+
+Task Compile -depends CompileSolutionA,CompileSolutionB
+
+Task Test -depends UnitTests,IntegrationTests
+
+Task CompileSolutionA -description 'Compiles solution A' {}
+
+Task CompileSolutionB {}
+
+Task UnitTests -alias 'ut' {}
+
+Task IntegrationTests {}

--- a/specs/structuredDocs_should_pass.ps1
+++ b/specs/structuredDocs_should_pass.ps1
@@ -1,0 +1,37 @@
+Task default -depends CheckStructuredDocs
+
+function Assert-EqualArrays($a, $b, $message)
+{
+    $differences = @(Compare-Object $a $b -SyncWindow 0)
+    if ($differences.Length -gt 0)
+    {
+        $differences
+    }
+    Assert ($differences.Length -eq 0) "$message : $($differences.Length) differences found."
+}
+
+function Assert-TaskEqual($t1, $t2)
+{
+    Assert ($t1.Name -eq $t2.Name)                "Task names do not match: $($t1.Name) vs $($t2.Name)"
+    Assert ($t1.Alias -eq $t2.Alias)              "Task aliases do not match for task $($t1.Name): $($t1.Alias) vs $($t2.Alias)"
+    Assert ($t1.Description -eq $t2.Description)  "Task descriptions do not match for task $($t1.Name): $($t1.Description) vs $($t2.Description)"
+    Assert ($t1.Default -eq $t2.Default)          "Task 'defaults' do not match for task $($t1.Name): $($t1.Default) vs $($t2.Default)"
+
+    Assert-EqualArrays $t1.DependsOn $t2.DependsOn "Task dependencies do not match for task $($t1.Name)"
+}
+
+Task CheckStructuredDocs {
+    
+    $tasks = Invoke-psake .\nested\docs.ps1 -structuredDocs
+    $tasks = $tasks | sort -Property Name
+
+    Assert ($tasks.Length -eq 7) 'Unexpected number of tasks.'
+
+    Assert-TaskEqual $tasks[0] ([pscustomobject]@{Name = 'Compile';          Alias = '';   Description = '';                    DependsOn = @('CompileSolutionA','CompileSolutionB'); Default = $true;})
+    Assert-TaskEqual $tasks[1] ([pscustomobject]@{Name = 'CompileSolutionA'; Alias = '';   Description = 'Compiles solution A'; DependsOn = @();                                      Default = $null;})
+    Assert-TaskEqual $tasks[2] ([pscustomobject]@{Name = 'CompileSolutionB'; Alias = '';   Description = '';                    DependsOn = @();                                      Default = $null;})
+    Assert-TaskEqual $tasks[3] ([pscustomobject]@{Name = 'default';          Alias = '';   Description = '';                    DependsOn = @('Compile','Test');                      Default = $null;})
+    Assert-TaskEqual $tasks[4] ([pscustomobject]@{Name = 'IntegrationTests'; Alias = '';   Description = '';                    DependsOn = @();                                      Default = $null;})
+    Assert-TaskEqual $tasks[5] ([pscustomobject]@{Name = 'Test';             Alias = '';   Description = '';                    DependsOn = @('UnitTests','IntegrationTests');        Default = $true;})
+    Assert-TaskEqual $tasks[6] ([pscustomobject]@{Name = 'UnitTests';        Alias = 'ut'; Description = '';                    DependsOn = @();                                      Default = $null;})
+}


### PR DESCRIPTION
The -structuredDocs can be used to return raw (non-formatted) meta data to
the calling script. This makes it possible to consume this meta data from
a script and do something meaningfull with it.

At the same time, some errors were fixed in the documentation (-detailedDocs
was not visible in the help of invoke-psake).

Tests were also added for -docs and -detailedDocs.