### PR TITLE
Greg Mcguffey patch: fix table formatting in documents

### DIFF
--- a/docs/structure-of-a-psake-build-script.md
+++ b/docs/structure-of-a-psake-build-script.md
@@ -3,6 +3,7 @@ A psake build script contains calls to functions that the psake build engine wil
 The functions are the following:
 
 |Function|Description|Required|
+|--------|-----------|--------|
 |_Include()_|Call this function to have psake include the functions of another file into your script|no|
 |_Properties()_|Call this function to set your properties|no|
 |_Task()_|This is the main function that you write to execute a step in your build script. NOTE: There can be only one task function that is named "default" in your psake script and it cannot contain any code. psake will throw an exception if it finds more than one default task function or if the default task function contains code|yes|

--- a/docs/structure-of-a-psake-build-script.md
+++ b/docs/structure-of-a-psake-build-script.md
@@ -34,7 +34,8 @@ Task Clean {
 <hr/>
 <p>The following is a BNF for a psake build script:</p>
 
-pre. <BuildScript> ::= <Includes> 
+```
+<BuildScript> ::= <Includes> 
                 | <Properties>
                 | <FormatTaskName> 
                 | <TaskSetup> 
@@ -58,3 +59,4 @@ pre. <BuildScript> ::= <Includes>
 <TaskNames> ::= <StringLiteral>, | <TaskNames>				
 <ScriptBlock> ::= { <PowerShellStatements> }
 <Boolean> ::= $true | $false
+```

--- a/docs/structure-of-a-psake-build-script.md
+++ b/docs/structure-of-a-psake-build-script.md
@@ -16,7 +16,7 @@ The functions are the following:
 An example psake script:
 <hr/>
 
-```
+```PowerShell
 Task default -Depends Test
 
 Task Test -Depends Compile, Clean {


### PR DESCRIPTION
I was reading about psake and one of the pages had bad formatting and made it very hard to figure out what was going on. The following was done:
  
  * Fixed format of function table
  * Added PowerShell syntax highlighting to code sample.
  * Used a code block instead of the _pre._ (which didn't work) for the BNF.

