### PR TITLE
Unload all user modules when build finishes.

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -476,16 +476,30 @@ function LoadModules {
 
         $global = [string]::Equals($scope, "global", [StringComparison]::CurrentCultureIgnoreCase)
 
-        $currentConfig.modules | foreach {
-            resolve-path $_ | foreach {
-                "Loading module: $_"
-                $module = import-module $_ -passthru -DisableNameChecking -global:$global
-                if (!$module) {
-                    throw ($msgs.error_loading_module -f $_.Name)
+        $psake.loaded_modules += (
+            $currentConfig.modules | foreach {
+                resolve-path $_ | foreach {
+                    Write-Host "Loading module: $_"
+                    $module = import-module $_ -passthru -DisableNameChecking -global:$global
+                    if (!$module) {
+                        throw ($msgs.error_loading_module -f $_.Name)
+                    }
+
+                    $module
                 }
             }
-        }
+        )
         ""
+    }
+}
+
+function UnloadModules {
+    if ($psake.loaded_modules) {
+        $psake.loaded_modules | foreach {
+                Write-Verbose "Removing module: $($_.Name)"
+                remove-module $_
+        }
+        $psake.loaded_modules = @()
     }
 }
 
@@ -705,6 +719,10 @@ function CleanupEnvironment {
         $global:ErrorActionPreference = $currentContext.originalErrorActionPreference
         [void] $psake.context.Pop()
     }
+
+    if ($psake.context.Count -eq 0) {
+        UnloadModules
+    }
 }
 
 function SelectObjectWithDefault
@@ -919,6 +937,7 @@ $psake.config_default = new-object psobject -property @{
 $psake.build_success = $false # indicates that the current build was successful
 $psake.build_script_file = $null # contains a System.IO.FileInfo for the current build script
 $psake.build_script_dir = "" # contains a string with fully-qualified path to current build script
+$psake.loaded_modules = @()
 
 LoadConfiguration
 


### PR DESCRIPTION
When the build script (e.g. psake.ps1) is ran from a powershell window and modules are loaded globally (to enable code sharing), they 

1. pollute the current shell
2. running the build multiple times will not pick up the changes in the modules

`2` could be solved by using `Import-Module -Force` in `LoadModules`, but `1` requires that Psake unloads all loaded modules when finished.

To make the code less complicated (e.g. managing nested imports), all loaded modules are tracked and unloaded only when all builds are done (the last scope have been cleaned up).

No idea how to write tests for this tho, the current test runner does not allow me to run tests _after_ the build have finished.