### PR TITLE
Spelling fixes in docs and script comments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -12,7 +12,7 @@ psake is pronounced sake – as in Japanese rice wine. It does NOT rhyme with ma
 
 **Step 1:** Download and extract the project
 
-You will need to "unblock" the zip file before extracting - PowerShell by default does not run files downloaded from the internet.
+You will need to "unblock" the zip file before extracting - PowerShell by default does not run files downloaded from the Internet.
 Just right-click the zip and click on "properties" and click on the "unblock" button.
 
 **Step 2:** CD into the directory where you extracted the project (where the psake.psm1 file is)
@@ -43,7 +43,7 @@ You can find all the information about each release of psake in the [releases se
 
 ## How To Contribute, Collaborate, Communicate
 
-If you'd like to get involved with psake, we have discussion groups over at google: **[psake-dev](http://groups.google.com/group/psake-dev)** **[psake-users](http://groups.google.com/group/psake-users)**
+If you'd like to get involved with psake, we have discussion groups over at Google: **[psake-dev](http://groups.google.com/group/psake-dev)** **[psake-users](http://groups.google.com/group/psake-users)**
 
 Anyone can fork the main repository and submit patches, as well. And lastly, the [wiki](http://wiki.github.com/psake/psake/) and [issues list](http://github.com/psake/psake/issues) are also open for additions, edits, and discussion.
 

--- a/docs/dot-net-solution.md
+++ b/docs/dot-net-solution.md
@@ -60,7 +60,7 @@ Import-Module (join-path $scriptPath psake.psm1)
 invoke-psake -framework '4.0'
 ```
 
-I run the build in powershell by just running the script:
+I run the build in PowerShell by just running the script:
 
 ```
 PS > .\run-build.ps1

--- a/docs/getting-help.md
+++ b/docs/getting-help.md
@@ -1,6 +1,6 @@
-You can read this faq for help on how to use psake.
+You can read this FAQ for help on how to use psake.
 
-You can also use the powershell command-let get-help on the *Invoke-psake* function to get more detailed help.
+You can also use the PowerShell command-let get-help on the *Invoke-psake* function to get more detailed help.
 
 ```powershell
 # First import the psake.psm1 file
@@ -28,7 +28,7 @@ Function        TaskSetup                                                     ..
 Function        TaskTearDown                                                  ...
 ```
 
-To Get example usage for individual functions in the psake powershell module, use Get-Help, For example:
+To Get example usage for individual functions in the psake PowerShell module, use Get-Help, For example:
 
 ```
 C:\Software\psake> Get-Help Assert -examples

--- a/docs/how-to-fail-a-build.md
+++ b/docs/how-to-fail-a-build.md
@@ -42,7 +42,7 @@ task TaskA {
   cmd /c exit (1) 
   if ($lastexitcode -ne 0)
   {
-    throw "Comand-line program failed"
+    throw "Command-line program failed"
   }
 }
 ```

--- a/psake.psm1
+++ b/psake.psm1
@@ -352,7 +352,7 @@ function Invoke-psake {
           $buildFile = $psake.config_default.buildFileName
         }
         elseif (!(test-path $buildFile -pathType Leaf) -and (test-path $psake.config_default.buildFileName -pathType Leaf)) {
-            # If the $config.buildFileName file exists and the given "buildfile" isn 't found assume that the given
+            # If the $config.buildFileName file exists and the given "buildfile" isn't found assume that the given
             # $buildFile is actually the target Tasks to execute in the $config.buildFileName script.
             $taskList = $buildFile.Split(', ')
             $buildFile = $psake.config_default.buildFileName
@@ -914,7 +914,7 @@ $psake.config_default = new-object psobject -property @{
     coloredOutput = $true;
     modules = $null;
     moduleScope = "";
-} # contains default configuration, can be overriden in psake-config.ps1 in directory with psake.psm1 or in directory with current build script
+} # contains default configuration, can be overridden in psake-config.ps1 in directory with psake.psm1 or in directory with current build script
 
 $psake.build_success = $false # indicates that the current build was successful
 $psake.build_script_file = $null # contains a System.IO.FileInfo for the current build script

--- a/specs/using_initialization_block_should_pass.ps1
+++ b/specs/using_initialization_block_should_pass.ps1
@@ -11,7 +11,7 @@ task default -depends TestInit
 task TestInit {
   # values are:
   # 1: original
-  # 2: overide
+  # 2: override
   # 3: new
   
   Assert ($container.foo -eq "foo") "$container.foo should be foo"

--- a/tabexpansion/Readme.PsakeTab.txt
+++ b/tabexpansion/Readme.PsakeTab.txt
@@ -1,5 +1,5 @@
 _________________________________________________________
-A powershell script for tab completion of psake module build commands
+A PowerShell script for tab completion of psake module build commands
  - tab completion for file name: psake d<tab> -> psake .\default.ps1
  - tab completion for parameters (docs,task,parameters,properties): psake -t<tab> -> psake -task
  - tab completion for task: psake -t<tab> c -> psake -task Clean


### PR DESCRIPTION
- PowerShell
- Internet
- Google
- FAQ
- command
- overridden
- override
- isn't
