### PR TITLE
Solve some portability issues with PS Core 6.x on MacOSX

### DIFF
--- a/psake-buildTester.ps1
+++ b/psake-buildTester.ps1
@@ -8,7 +8,7 @@ function Main()
 	remove-module psake
 
 	""
-	$results | Sort 'Name' | % { if ($_.Result -eq "Passed") { write-host ($_.Name + " (Passed)") -ForeGroundColor 'GREEN'} else { write-host ($_.Name + " (Failed)") -ForeGroundColor 'RED'}} 
+	$results | Sort-Object 'Name' | % { if ($_.Result -eq "Passed") { write-host ($_.Name + " (Passed)") -ForeGroundColor 'GREEN'} else { write-host ($_.Name + " (Failed)") -ForeGroundColor 'RED'}} 
 	""
 
 	$failed = $results | ? { $_.Result -eq "Failed" }
@@ -26,7 +26,7 @@ function Main()
 
 function runBuilds()
 {
-	$buildFiles = ls specs\*.ps1
+	$buildFiles = Get-ChildItem specs\*.ps1
 	$testResults = @()
 
 	#Add a fake build file to the $buildFiles array so that we can verify

--- a/psake.psm1
+++ b/psake.psm1
@@ -544,103 +544,105 @@ function CreateConfigurationForNewContext {
 }
 
 function ConfigureBuildEnvironment {
-    $framework = $psake.context.peek().config.framework
-    if ($framework -cmatch '^((?:\d+\.\d+)(?:\.\d+){0,1})(x86|x64){0,1}$') {
-        $versionPart = $matches[1]
-        $bitnessPart = $matches[2]
-    } else {
-        throw ($msgs.error_invalid_framework -f $framework)
-    }
-    $versions = $null
-    $buildToolsVersions = $null
-    switch ($versionPart) {
-        '1.0' {
-            $versions = @('v1.0.3705')
+    if (!(Get-Variable -Name IsWindows -ErrorAction SilentlyContinue) -or $IsWindows) {
+        $framework = $psake.context.peek().config.framework
+        if ($framework -cmatch '^((?:\d+\.\d+)(?:\.\d+){0,1})(x86|x64){0,1}$') {
+            $versionPart = $matches[1]
+            $bitnessPart = $matches[2]
+        } else {
+            throw ($msgs.error_invalid_framework -f $framework)
         }
-        '1.1' {
-            $versions = @('v1.1.4322')
-        }
-        '2.0' {
-            $versions = @('v2.0.50727')
-        }
-        '3.0' {
-            $versions = @('v2.0.50727')
-        }
-        '3.5' {
-            $versions = @('v3.5', 'v2.0.50727')
-        }
-        '4.0' {
-            $versions = @('v4.0.30319')
-        }
-        {($_ -eq '4.5.1') -or ($_ -eq '4.5.2')} {
-            $versions = @('v4.0.30319')
-            $buildToolsVersions = @('14.0', '12.0')
-        }
-        {($_ -eq '4.6') -or ($_ -eq '4.6.1')} {
-            $versions = @('v4.0.30319')
-            $buildToolsVersions = @('14.0')
+        $versions = $null
+        $buildToolsVersions = $null
+        switch ($versionPart) {
+            '1.0' {
+                $versions = @('v1.0.3705')
+            }
+            '1.1' {
+                $versions = @('v1.1.4322')
+            }
+            '2.0' {
+                $versions = @('v2.0.50727')
+            }
+            '3.0' {
+                $versions = @('v2.0.50727')
+            }
+            '3.5' {
+                $versions = @('v3.5', 'v2.0.50727')
+            }
+            '4.0' {
+                $versions = @('v4.0.30319')
+            }
+            {($_ -eq '4.5.1') -or ($_ -eq '4.5.2')} {
+                $versions = @('v4.0.30319')
+                $buildToolsVersions = @('14.0', '12.0')
+            }
+            {($_ -eq '4.6') -or ($_ -eq '4.6.1')} {
+                $versions = @('v4.0.30319')
+                $buildToolsVersions = @('14.0')
+            }
+
+            default {
+                throw ($msgs.error_unknown_framework -f $versionPart, $framework)
+            }
         }
 
-        default {
-            throw ($msgs.error_unknown_framework -f $versionPart, $framework)
-        }
-    }
-
-    $bitness = 'Framework'
-    if ($versionPart -ne '1.0' -and $versionPart -ne '1.1') {
-        switch ($bitnessPart) {
-            'x86' {
-                $bitness = 'Framework'
-                $buildToolsKey = 'MSBuildToolsPath32'
-            }
-            'x64' {
-                $bitness = 'Framework64'
-                $buildToolsKey = 'MSBuildToolsPath'
-            }
-            { [string]::IsNullOrEmpty($_) } {
-                $ptrSize = [System.IntPtr]::Size
-                switch ($ptrSize) {
-                    4 {
-                        $bitness = 'Framework'
-                        $buildToolsKey = 'MSBuildToolsPath32'
-                    }
-                    8 {
-                        $bitness = 'Framework64'
-                        $buildToolsKey = 'MSBuildToolsPath'
-                    }
-                    default {
-                        throw ($msgs.error_unknown_pointersize -f $ptrSize)
+        $bitness = 'Framework'
+        if ($versionPart -ne '1.0' -and $versionPart -ne '1.1') {
+            switch ($bitnessPart) {
+                'x86' {
+                    $bitness = 'Framework'
+                    $buildToolsKey = 'MSBuildToolsPath32'
+                }
+                'x64' {
+                    $bitness = 'Framework64'
+                    $buildToolsKey = 'MSBuildToolsPath'
+                }
+                { [string]::IsNullOrEmpty($_) } {
+                    $ptrSize = [System.IntPtr]::Size
+                    switch ($ptrSize) {
+                        4 {
+                            $bitness = 'Framework'
+                            $buildToolsKey = 'MSBuildToolsPath32'
+                        }
+                        8 {
+                            $bitness = 'Framework64'
+                            $buildToolsKey = 'MSBuildToolsPath'
+                        }
+                        default {
+                            throw ($msgs.error_unknown_pointersize -f $ptrSize)
+                        }
                     }
                 }
-            }
-            default {
-                throw ($msgs.error_unknown_bitnesspart -f $bitnessPart, $framework)
-            }
-        }
-    }
-    $frameworkDirs = @()
-    if ($buildToolsVersions -ne $null) {
-        foreach($ver in $buildToolsVersions) {
-            if (Test-Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver") {
-                $frameworkDirs += (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver" -Name $buildToolsKey).$buildToolsKey
+                default {
+                    throw ($msgs.error_unknown_bitnesspart -f $bitnessPart, $framework)
+                }
             }
         }
-    }
-    $frameworkDirs = $frameworkDirs + @($versions | foreach { "$env:windir\Microsoft.NET\$bitness\$_\" })
-
-    for ($i = 0; $i -lt $frameworkDirs.Count; $i++) {
-        $dir = $frameworkDirs[$i]
-        if ($dir -Match "\$\(Registry:HKEY_LOCAL_MACHINE(.*?)@(.*)\)") {
-            $key = "HKLM:" + $matches[1]
-            $name = $matches[2]
-            $dir = (Get-ItemProperty -Path $key -Name $name).$name
-            $frameworkDirs[$i] = $dir
+        $frameworkDirs = @()
+        if ($buildToolsVersions -ne $null) {
+            foreach($ver in $buildToolsVersions) {
+                if (Test-Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver") {
+                    $frameworkDirs += (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver" -Name $buildToolsKey).$buildToolsKey
+                }
+            }
         }
+        $frameworkDirs = $frameworkDirs + @($versions | foreach { "$env:windir\Microsoft.NET\$bitness\$_\" })
+
+        for ($i = 0; $i -lt $frameworkDirs.Count; $i++) {
+            $dir = $frameworkDirs[$i]
+            if ($dir -Match "\$\(Registry:HKEY_LOCAL_MACHINE(.*?)@(.*)\)") {
+                $key = "HKLM:" + $matches[1]
+                $name = $matches[2]
+                $dir = (Get-ItemProperty -Path $key -Name $name).$name
+                $frameworkDirs[$i] = $dir
+            }
+        }
+
+        $frameworkDirs | foreach { Assert (test-path $_ -pathType Container) ($msgs.error_no_framework_install_dir_found -f $_)}
+
+        $env:path = ($frameworkDirs -join ";") + ";$env:path"
     }
-
-    $frameworkDirs | foreach { Assert (test-path $_ -pathType Container) ($msgs.error_no_framework_install_dir_found -f $_)}
-
-    $env:path = ($frameworkDirs -join ";") + ";$env:path"
     # if any error occurs in a PS function then "stop" processing immediately
     # this does not effect any external programs that return a non-zero exit code
     $global:ErrorActionPreference = "Stop"
@@ -832,9 +834,9 @@ function WriteDocumentation($showDetailed) {
                 }
 
     if ($showDetailed) {
-        $docs | sort 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default
+        $docs | Sort-Object 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default
     } else {
-        $docs | sort 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description
+        $docs | Sort-Object 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description
     }
 }
 

--- a/specs/Get-PSakeScriptTasks_should_pass.ps1
+++ b/specs/Get-PSakeScriptTasks_should_pass.ps1
@@ -27,7 +27,7 @@ function HelloYou
 Task CheckGetPSakeScriptTasks {
     
     $tasks = Get-PSakeScriptTasks .\nested\docs.ps1
-    $tasks = $tasks | sort -Property Name
+    $tasks = $tasks | Sort-Object -Property Name
 
     Assert ($tasks.Length -eq 7) 'Unexpected number of tasks.'
 

--- a/tabexpansion/PsakeTabExpansion.ps1
+++ b/tabexpansion/PsakeTabExpansion.ps1
@@ -16,16 +16,16 @@ function script:psakeFiles($filter) {
 function PsakeTabExpansion($lastBlock) {
   switch -regex ($lastBlock) {
     '(invoke-psake|psake) ([^\.]*\.ps1)? ?.* ?\-ta?s?k? (\S*)$' { # tasks only
-      psakeDocs $matches[3] $matches[2] | sort
+      psakeDocs $matches[3] $matches[2] | Sort-Object
     } 
     '(invoke-psake|psake) ([^\.]*\.ps1)? ?.* ?(\-\S*)$' { # switches only
-      psakeSwitches $matches[3] | sort
+      psakeSwitches $matches[3] | Sort-Object
     } 
     '(invoke-psake|psake) ([^\.]*\.ps1) ?.* ?(\S*)$' { # switches or tasks
-      @(psakeDocs $matches[3] $matches[2]) + @(psakeSwitches $matches[3]) | sort
+      @(psakeDocs $matches[3] $matches[2]) + @(psakeSwitches $matches[3]) | Sort-Object
     }
     '(invoke-psake|psake) (\S*)$' {
-      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'default.ps1') + @(psakeSwitches $matches[2]) | sort
+      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'default.ps1') + @(psakeSwitches $matches[2]) | Sort-Object
     }
   }
 }


### PR DESCRIPTION
This should solve #197. The solution I came up with in the end was to simply check for the presence and value of `$IsWindows`:

```
if (!(Get-Variable -Name IsWindows -ErrorAction SilentlyContinue) -and !$IsWindows)
```

This variable should be present in PS Core and set to $True on windows. So if that variable is not present or if it is true we detect frameworks. If not this part is simply ignored.

The rest of the changes are only aliases that I had to replace with their full cmdlet names because they do not exist under MacOSX or Linux.