### PR TITLE
Add working directory option to Exec function

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -144,7 +144,13 @@ function Exec
         [Parameter(Position=1,Mandatory=0)][string]$errorMessage = ($msgs.error_bad_command -f $cmd),
         [Parameter(Position=2,Mandatory=0)][int]$maxRetries = 0,
         [Parameter(Position=3,Mandatory=0)][string]$retryTriggerErrorPattern = $null
+        [Parameter(Position=4,Mandatory=0)][string]$workingDirectory = $null
     )
+	
+    if($workingDirectory)
+    {
+        Push-Location -Path $workingDirectory
+    }
 
     $tryCount = 1
 
@@ -176,6 +182,13 @@ function Exec
             $tryCount++
 
             [System.Threading.Thread]::Sleep([System.TimeSpan]::FromSeconds(1))
+        }
+        finally
+        {
+            if($workingDirectory)
+            {
+                Pop-Location
+            }
         }
     }
     while ($true)


### PR DESCRIPTION
New pull request as replace for: #135 

@alexandear @gep13 I like the suggestion of @rvdginste. It's a good idea to move the Pop-Location statement to a finally block. With my solution, the user could end up in a wrong directory, if some script/exe fails. 
Sadly, I’ve removed my fork of psake and can therefore not modify my commit.
That’s the reason why I’ve created a new pull request for the working directory feature.