### PR TITLE
Allow greater than .net 4.6.1 and build tools 2017

### DIFF
--- a/NuGetPackageBuilder.ps1
+++ b/NuGetPackageBuilder.ps1
@@ -23,6 +23,6 @@ Copy-Item -Recurse $dir\nuget $destDir
 Copy-Item -Recurse $dir\en-US $destDir\tools\en-US
 Copy-Item -Recurse $dir\examples $destDir\tools\examples
 @( "psake.cmd", "psake.ps1", "psake.psm1", "psake.psd1", "psake-config.ps1", "README.markdown", "license.txt") |
-    % { Copy-Item $dir\$_ $destDir\tools }
+    ForEach-Object { Copy-Item $dir\$_ $destDir\tools }
 
 .\nuget pack "$destDir\psake.nuspec" -Verbosity quiet -Version $version

--- a/psake-buildTester.ps1
+++ b/psake-buildTester.ps1
@@ -8,10 +8,10 @@ function Main()
 	remove-module psake
 
 	""
-	$results | Sort 'Name' | % { if ($_.Result -eq "Passed") { write-host ($_.Name + " (Passed)") -ForeGroundColor 'GREEN'} else { write-host ($_.Name + " (Failed)") -ForeGroundColor 'RED'}} 
+	$results | Sort-Object 'Name' | ForEach-Object { if ($_.Result -eq "Passed") { write-host ($_.Name + " (Passed)") -ForeGroundColor 'GREEN'} else { write-host ($_.Name + " (Failed)") -ForeGroundColor 'RED'}} 
 	""
 
-	$failed = $results | ? { $_.Result -eq "Failed" }
+	$failed = $results | Where-Object { $_.Result -eq "Failed" }
 	if ($failed) 
 	{	
 		write-host "One or more of the build files failed" -ForeGroundColor RED
@@ -26,19 +26,19 @@ function Main()
 
 function runBuilds()
 {
-	$buildFiles = ls specs\*.ps1
+	$buildFiles = Get-ChildItem specs\*.ps1
 	$testResults = @()
 
 	#Add a fake build file to the $buildFiles array so that we can verify
 	#that Invoke-psake fails
-	$non_existant_buildfile = "" | select Name, FullName
+	$non_existant_buildfile = "" | Select-Object Name, FullName
 	$non_existant_buildfile.Name = "specifying_a_non_existant_buildfile_should_fail.ps1"
 	$non_existant_buildfile.FullName = "c:\specifying_a_non_existant_buildfile_should_fail.ps1"
 	$buildFiles += $non_existant_buildfile
 
 	foreach($buildFile in $buildFiles) 
 	{		
-		$testResult = "" | select Name, Result
+		$testResult = "" | Select-Object Name, Result
 		$testResult.Name = $buildFile.Name
 		invoke-psake $buildFile.FullName -Parameters @{'p1'='v1'; 'p2'='v2'} -Properties @{'x'='1'; 'y'='2'} -Initialization { if(!$container) { $container = @{}; } $container.bar = "bar"; $container.baz = "baz"; $bar = 2; $baz = 3 } | Out-Null
 		$testResult.Result = (getResult $buildFile.Name $psake.build_success)

--- a/psake.psm1
+++ b/psake.psm1
@@ -476,8 +476,8 @@ function LoadModules {
 
         $global = [string]::Equals($scope, "global", [StringComparison]::CurrentCultureIgnoreCase)
 
-        $currentConfig.modules | foreach {
-            resolve-path $_ | foreach {
+        $currentConfig.modules | ForEach-Object {
+            resolve-path $_ | ForEach-Object {
                 "Loading module: $_"
                 $module = import-module $_ -passthru -DisableNameChecking -global:$global
                 if (!$module) {
@@ -626,7 +626,7 @@ function ConfigureBuildEnvironment {
             }
         }
     }
-    $frameworkDirs = $frameworkDirs + @($versions | foreach { "$env:windir\Microsoft.NET\$bitness\$_\" })
+    $frameworkDirs = $frameworkDirs + @($versions | ForEach-Object { "$env:windir\Microsoft.NET\$bitness\$_\" })
 
     for ($i = 0; $i -lt $frameworkDirs.Count; $i++) {
         $dir = $frameworkDirs[$i]
@@ -638,7 +638,7 @@ function ConfigureBuildEnvironment {
         }
     }
 
-    $frameworkDirs | foreach { Assert (test-path $_ -pathType Container) ($msgs.error_no_framework_install_dir_found -f $_)}
+    $frameworkDirs | ForEach-Object { Assert (test-path $_ -pathType Container) ($msgs.error_no_framework_install_dir_found -f $_)}
 
     $env:path = ($frameworkDirs -join ";") + ";$env:path"
     # if any error occurs in a PS function then "stop" processing immediately
@@ -783,8 +783,8 @@ function ResolveError
             SelectObjectWithDefault -Name 'PositionMessage' -Value '') -replace "`n", ' '),
             ($_ | SelectObjectWithDefault -Name 'Message' -Value ''),
             ($_ | SelectObjectWithDefault -Name 'Exception' -Value '') |
-                ? { -not [String]::IsNullOrEmpty($_) } |
-                Select -First 1
+                Where-Object { -not [String]::IsNullOrEmpty($_) } |
+                Select-Object -First 1
 
         $delimiter = ''
         if ((-not [String]::IsNullOrEmpty($header)) -and
@@ -822,8 +822,8 @@ function WriteDocumentation($showDetailed) {
     }
     
     $docs = GetTasksFromContext $currentContext | 
-                Where   {$_.Name -ne 'default'} | 
-                ForEach {
+                Where-Object {$_.Name -ne 'default'} | 
+                ForEach-Object {
                     $isDefault = $null
                     if ($defaultTaskDependencies -contains $_.Name) { 
                         $isDefault = $true 
@@ -832,9 +832,9 @@ function WriteDocumentation($showDetailed) {
                 }
 
     if ($showDetailed) {
-        $docs | sort 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default
+        $docs | Sort-Object 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default
     } else {
-        $docs | sort 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description
+        $docs | Sort-Object 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description
     }
 }
 
@@ -904,9 +904,9 @@ $manifest = Test-ModuleManifest -Path $manifestPath -WarningAction SilentlyConti
 $script:psake = @{}
 
 $psake.version = $manifest.Version.ToString()
-$psake.context = new-object system.collections.stack # holds onto the current state of all variables
+$psake.context = New-Object system.collections.stack # holds onto the current state of all variables
 $psake.run_by_psake_build_tester = $false # indicates that build is being run by psake-BuildTester
-$psake.config_default = new-object psobject -property @{
+$psake.config_default = New-Object psobject -property @{
     buildFileName = "default.ps1";
     framework = "4.0";
     taskNameFormat = "Executing {0}";

--- a/psake.psm1
+++ b/psake.psm1
@@ -576,7 +576,7 @@ function ConfigureBuildEnvironment {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0', '12.0')
         }
-        {($_ -ge '4.6')} {
+        {($_ -ge '4.6') -and ($_ -le '4.6.9')} {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0')
         }
@@ -621,6 +621,9 @@ function ConfigureBuildEnvironment {
     $frameworkDirs = @()
     if ($buildToolsVersions -ne $null) {
         foreach($ver in $buildToolsVersions) {
+            if ($ver -eq "15.0" -and (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2017")) {
+
+            }
             if (Test-Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver") {
                 $frameworkDirs += (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver" -Name $buildToolsKey).$buildToolsKey
             }

--- a/psake.psm1
+++ b/psake.psm1
@@ -576,7 +576,7 @@ function ConfigureBuildEnvironment {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0', '12.0')
         }
-        {($_ -eq '4.6') -or ($_ -eq '4.6.1')} {
+        {($_ -ge '4.6')} {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0')
         }

--- a/psake.psm1
+++ b/psake.psm1
@@ -576,9 +576,13 @@ function ConfigureBuildEnvironment {
             $versions = @('v4.0.30319')
             $buildToolsVersions = @('14.0', '12.0')
         }
-        {($_ -ge '4.6') -and ($_ -le '4.6.9')} {
+        {($_ -ge '4.6') -or ($_ -eq '4.6.2')} {
             $versions = @('v4.0.30319')
-            $buildToolsVersions = @('14.0')
+            $buildToolsVersions = @('15','14.0')
+        }
+        {($_ -ge '4.7') -and ($_ -le '4.7.9')} {
+            $versions = @('v4.0.30319')
+            $buildToolsVersions = @('15')
         }
 
         default {
@@ -621,9 +625,18 @@ function ConfigureBuildEnvironment {
     $frameworkDirs = @()
     if ($buildToolsVersions -ne $null) {
         foreach($ver in $buildToolsVersions) {
-            if ($ver -eq "15.0" -and (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2017")) {
+            if ($ver -eq "15" -and (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2017")) {
+                $2017BuildTools = get-childitem -Path 'C:\Program Files (x86)\Microsoft Visual Studio\2017\' -Recurse -Filter "msbuild.exe"
 
+                if ($buildToolsKey -eq 'MSBuildToolsPath') {
+                    $2017BuildTools_AMD64 = $2017BuildTools | Where-Object {$_.directory -match 'amd64'}
+                    $frameworkDirs += $2017BuildTools_AMD64.DirectoryName
+                } else {
+                    $2017BuildTools = $2017BuildTools | Where-Object {$_.directory -notmatch 'amd64'}
+                    $frameworkDirs += $2017BuildTools.DirectoryName
+                }
             }
+            
             if (Test-Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver") {
                 $frameworkDirs += (Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\$ver" -Name $buildToolsKey).$buildToolsKey
             }

--- a/specs/dotNet4.6.2_should_pass.ps1
+++ b/specs/dotNet4.6.2_should_pass.ps1
@@ -1,0 +1,8 @@
+Framework "4.6.2"
+
+task default -depends MsBuild
+
+task MsBuild {
+  $output = &msbuild /version 2>&1
+  Assert ($output -NotLike "14.0") '$output should contain 14.0'
+}

--- a/specs/dotNet4.7_should_pass.ps1
+++ b/specs/dotNet4.7_should_pass.ps1
@@ -1,0 +1,8 @@
+Framework "4.7"
+
+task default -depends MsBuild
+
+task MsBuild {
+  $output = &msbuild /version 2>&1
+  Assert ($output -NotLike "15") '$output should contain 15'
+}

--- a/tabexpansion/PsakeTabExpansion.ps1
+++ b/tabexpansion/PsakeTabExpansion.ps1
@@ -1,31 +1,33 @@
 $global:psakeSwitches = @('-docs', '-task', '-properties', '-parameters')
 
 function script:psakeSwitches($filter) {  
-  $psakeSwitches | where { $_ -like "$filter*" }
+  $psakeSwitches | Where-Object { $_ -like "$filter*" }
 }
 
 function script:psakeDocs($filter, $file) {
   if ($file -eq $null -or $file -eq '') { $file = 'default.ps1' }
-  psake $file -docs | out-string -Stream |% { if ($_ -match "^[^ ]*") { $matches[0]} } |? { $_ -ne "Name" -and $_ -ne "----" -and $_ -like "$filter*" }
+  psake $file -docs | out-string -Stream | 
+  ForEach-Object { if ($_ -match "^[^ ]*") { $matches[0]} } | 
+  ForEach-Object { $_ -ne "Name" -and $_ -ne "----" -and $_ -like "$filter*" }
 }
 
 function script:psakeFiles($filter) {
-    ls "$filter*.ps1" |% { $_.Name }
+    Get-ChildItem "$filter*.ps1" |% { $_.Name }
 }
 
 function PsakeTabExpansion($lastBlock) {
   switch -regex ($lastBlock) {
     '(invoke-psake|psake) ([^\.]*\.ps1)? ?.* ?\-ta?s?k? (\S*)$' { # tasks only
-      psakeDocs $matches[3] $matches[2] | sort
+      psakeDocs $matches[3] $matches[2] | Sort-Object
     } 
     '(invoke-psake|psake) ([^\.]*\.ps1)? ?.* ?(\-\S*)$' { # switches only
-      psakeSwitches $matches[3] | sort
+      psakeSwitches $matches[3] | Sort-Object
     } 
     '(invoke-psake|psake) ([^\.]*\.ps1) ?.* ?(\S*)$' { # switches or tasks
-      @(psakeDocs $matches[3] $matches[2]) + @(psakeSwitches $matches[3]) | sort
+      @(psakeDocs $matches[3] $matches[2]) + @(psakeSwitches $matches[3]) | Sort-Object
     }
     '(invoke-psake|psake) (\S*)$' {
-      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'default.ps1') + @(psakeSwitches $matches[2]) | sort
+      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'default.ps1') + @(psakeSwitches $matches[2]) | Sort-Object
     }
   }
 }


### PR DESCRIPTION
This seems to work to detect build tools for 2017 and .net 4.7. I have added tests for .net 4.6.2 and 4.7 it and I can get it to work locally. It is picking up my msbuild 15.1 tools. I have based it on path detection so PSake doesn't need to ship the msbuild setup powershell from here: https://github.com/Microsoft/vssetup.powershell