### PR TITLE
Fix spectests

### DIFF
--- a/specs/dotNet4.5.1_should_pass.ps1
+++ b/specs/dotNet4.5.1_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 12 -or 14) '$output should contain 12 or 14'
+  Assert ($output.Version.Major -eq 12 -or $output.Version.Major -eq 14) '$output should contain 12 or 14'
 }

--- a/specs/dotNet4.5.2_should_pass.ps1
+++ b/specs/dotNet4.5.2_should_pass.ps1
@@ -1,4 +1,4 @@
-Framework "4.5.1x86"
+Framework "4.5.2"
 
 task default -depends MsBuild
 

--- a/specs/dotNet4.5.2_should_pass.ps1
+++ b/specs/dotNet4.5.2_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 12 -or 14) '$output should contain 12 or 14'
+  Assert ($output.Version.Major -eq 12 -or $output.Version.Major -eq 14) '$output should contain 12 or 14'
 }

--- a/specs/dotNet4.6.1_should_pass.ps1
+++ b/specs/dotNet4.6.1_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 15 -or 14) '$output should contain 15 or 14'
+  Assert ($output.Version.Major -eq 15 -or $output.Version.Major -eq 14) '$output should contain 15 or 14'
 }

--- a/specs/dotNet4.6.2_should_pass.ps1
+++ b/specs/dotNet4.6.2_should_pass.ps1
@@ -1,4 +1,4 @@
-Framework "4.6.1"
+Framework "4.6.2"
 
 task default -depends MsBuild
 

--- a/specs/dotNet4.6.2_should_pass.ps1
+++ b/specs/dotNet4.6.2_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 15 -or 14) '$output should contain 15 or 14'
+  Assert ($output.Version.Major -eq 15 -or $output.Version.Major -eq 14) '$output should contain 15 or 14'
 }

--- a/specs/dotNet4.6_should_pass.ps1
+++ b/specs/dotNet4.6_should_pass.ps1
@@ -3,6 +3,6 @@ Framework "4.6"
 task default -depends MsBuild
 
 task MsBuild {
-  $output = &msbuild /version 2>&1
-  Assert ($output -NotLike "14.0") '$output should contain 14.0'
+  $output = get-command msbuild.exe
+  Assert ($output.Version.Major -like 15 -or 14) '$output should contain 15 or 14'
 }

--- a/specs/dotNet4.6_should_pass.ps1
+++ b/specs/dotNet4.6_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 15 -or 14) '$output should contain 15 or 14'
+  Assert ($output.Version.Major -eq 15 -or $output.Version.Major -eq 14) '$output should contain 15 or 14'
 }

--- a/specs/dotNet4.7_should_pass.ps1
+++ b/specs/dotNet4.7_should_pass.ps1
@@ -4,5 +4,5 @@ task default -depends MsBuild
 
 task MsBuild {
   $output = get-command msbuild.exe
-  Assert ($output.Version.Major -like 15) '$output should contain 15'
+  Assert ($output.Version.Major -eq 15) '$output should contain 15'
 }

--- a/specs/dotNet4.7_should_pass.ps1
+++ b/specs/dotNet4.7_should_pass.ps1
@@ -1,0 +1,8 @@
+Framework "4.7"
+
+task default -depends MsBuild
+
+task MsBuild {
+  $output = get-command msbuild.exe
+  Assert ($output.Version.Major -like 15) '$output should contain 15'
+}


### PR DESCRIPTION
This commit updates the spec tests for the .net version to look at the major version number of the msbuild tools instead of trying to inspect the output of `msbuild /v`. I also am not convinced the old tests were working correctly as they would pass even without the correct version of msbuild on my machine. .