### PR TITLE
Improve Build Time Report

### DIFF
--- a/psake.psm1
+++ b/psake.psm1
@@ -862,13 +862,13 @@ function WriteTaskTimeSummary($invokePsakeDuration) {
             }
             $list += new-object PSObject -property @{
                 Name = $task.Name;
-                Duration = $task.Duration
+                Duration = $task.Duration.ToString("hh\:mm\:ss\.fff")
             }
         }
         [Array]::Reverse($list)
         $list += new-object PSObject -property @{
             Name = "Total:";
-            Duration = $invokePsakeDuration
+            Duration = $invokePsakeDuration.ToString("hh\:mm\:ss\.fff")
         }
         # using "out-string | where-object" to filter out the blank line that format-table prepends
         $list | format-table -autoSize -property Name,Duration | out-string -stream | where-object { $_ }

--- a/psake.psm1
+++ b/psake.psm1
@@ -842,11 +842,18 @@ function WriteDocumentation($showDetailed) {
 
 function WriteTaskTimeSummary($invokePsakeDuration) {
     if ($psake.context.count -gt 0) {
-        "-" * 70
-        "Build Time Report"
-        "-" * 70
-        $list = @()
         $currentContext = $psake.context.Peek()
+        if ($currentContext.config.taskNameFormat -is [ScriptBlock]) {
+            & $currentContext.config.taskNameFormat "Build Time Report"
+        } elseif ($currentContext.config.taskNameFormat -ne "Executing {0}") {
+            $currentContext.config.taskNameFormat -f "Build Time Report"
+        }
+        else {  
+            "-" * 70
+            "Build Time Report"
+            "-" * 70
+        }
+        $list = @()
         while ($currentContext.executedTasks.Count -gt 0) {
             $taskKey = $currentContext.executedTasks.Pop()
             $task = $currentContext.tasks.$taskKey


### PR DESCRIPTION
Two minor changes.

If the build script defines a custom `FormatTaskName` then also use that to format the header for the *Build Time Report* shown at the end of the build. This improves the consistency of the build log for users who define a custom task header.

Show task timing to millisecond accuracy in the *Build Time Report* instead of to tenths of microseconds.