### PR TITLE
Add initial set of Pester tests and execute in AppVeyor/Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 [B|b]in
 *.nupkg
 Thumbs.db
-dotnet-install.ps1
+/dotnet-install.ps1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 
 script:
   - ulimit -n 4096
-  - powershell -File build/travis.ps1
+  - powershell -file build.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,5 +4,9 @@ skip_commits:
   message: /updated readme.*|update readme.*s/
 build: off
 
+before_test:
+  - echo script1
+  - ps: ./build/dotnet-install.ps1
+
 test_script:
-  - ps: ./build/travis.ps1
+  - ps: ./build.ps1

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,28 @@
+[cmdletbinding()]
+param()
+
+Get-PackageProvider -Name Nuget -ForceBootstrap -Verbose:$false | Out-Null
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted -Verbose:$false
+
+'Pester' | Foreach-Object {
+    if (-not (Get-Module -Name $_ -ErrorAction SilentlyContinue)) {
+        Install-Module -Name $_ -AllowClobber -Scope CurrentUser -Force
+        Import-Module -Name $_
+    }
+}
+
+if ($env:TRAVIS) {
+    . "$PSScriptRoot/build/travis.ps1"
+}
+
+$testResults = Invoke-Pester -Path ./tests -PassThru -OutputFile ./testResults.xml
+
+# Upload test artifacts to AppVeyor
+if ($env:APPVEYOR_JOB_ID) {
+    $wc = New-Object 'System.Net.WebClient'
+    $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path ./testResults.xml))
+}
+
+if ($testResults.FailedCount -gt 0) {
+    throw "$($testResults.FailedCount) tests failed!"
+}

--- a/build/dotnet-install.ps1
+++ b/build/dotnet-install.ps1
@@ -1,0 +1,10 @@
+# Setup dotnet
+. "$PSScriptRoot/tools.ps1"
+$dotnetArguments = @{
+    Channel = 'Current'
+    Version = 'latest'
+    NoSudo = $false
+}
+Install-Dotnet @dotnetArguments
+$Env:PATH += "$([IO.Path]::PathSeparator)$Env:HOME/.dotnet"
+dotnet build -version -nologo

--- a/build/travis.ps1
+++ b/build/travis.ps1
@@ -1,9 +1,9 @@
 
-$dotnetCLIChannel = "Current"
-$dotnetCLIRequiredVersion = "latest"
+$dotnetCLIChannel = 'Current'
+$dotnetCLIRequiredVersion = 'latest'
 $NoSudo = $false
 
-. build/tools.ps1
+. "$PSScriptRoot/tools.ps1"
 
 $DotnetArguments = @{ Channel = $dotnetCLIChannel; Version = $dotnetCLIRequiredVersion; NoSudo = $NoSudo }
 Install-Dotnet @DotnetArguments
@@ -14,7 +14,6 @@ $Env:PATH += "$([IO.Path]::PathSeparator)$Env:HOME/.dotnet"
 # Execute once to configure
 dotnet build -version -nologo
 
-
-
 # Execute Build Tester
-.\psake-buildTester.ps1
+#. "$PSScriptRoot/../build.ps1"
+#.\psake-buildTester.ps1

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -1,0 +1,107 @@
+
+
+# Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
+
+$manifestPath = "$PSScriptRoot/../psake.psd1"
+$manifest = Import-PowerShellDataFile -Path $manifestPath
+
+# Get module commands
+# Remove all versions of the module from the session. Pester can't handle multiple versions.
+Remove-Module -Name psake -Force
+Import-Module -Name $manifestPath -Force -Verbose:$false -ErrorAction Stop
+$commands = Get-Command -Module psake -CommandType Cmdlet, Function, Workflow  # Not alias
+
+## When testing help, remember that help is cached at the beginning of each session.
+## To test, restart session.
+
+foreach ($command in $commands) {
+    $commandName = $command.Name
+
+    # The module-qualified command fails on Microsoft.PowerShell.Archive cmdlets
+    $help = Get-Help $commandName -ErrorAction SilentlyContinue
+
+    Describe "Test help for $commandName" {
+
+        # If help is not found, synopsis in auto-generated help is the syntax diagram
+        It 'should not be auto-generated' {
+            $help.Synopsis | Should Not BeLike '*`[`<CommonParameters`>`]*'
+        }
+
+        # Should be a description for every function
+        It "gets description for $commandName" {
+            $help.Description | Should Not BeNullOrEmpty
+        }
+
+        # Should be at least one example
+        It "gets example code from $commandName" {
+            ($help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+        }
+
+        # Should be at least one example description
+        It "gets example help from $commandName" {
+            ($help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+        }
+
+        Context "Test parameter help for $commandName" {
+
+            $common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer',
+                'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'
+
+            $parameters = $command.ParameterSets.Parameters |
+                Sort-Object -Property Name -Unique |
+                Where-Object { $_.Name -notin $common }
+            $parameterNames = $parameters.Name
+
+            ## Without the filter, WhatIf and Confirm parameters are still flagged in "finds help parameter in code" test
+            $helpParameters = $help.Parameters.Parameter |
+                Where-Object { $_.Name -notin $common } |
+                Sort-Object -Property Name -Unique
+            $helpParameterNames = $helpParameters.Name
+
+            foreach ($parameter in $parameters) {
+                $parameterName = $parameter.Name
+                $parameterHelp = $help.parameters.parameter | Where-Object Name -EQ $parameterName
+
+                # Should be a description for every parameter
+                It "gets help for parameter: $parameterName : in $commandName" {
+                    $parameterHelp.Description.Text | Should Not BeNullOrEmpty
+                }
+
+                # Required value in Help should match IsMandatory property of parameter
+                It "help for $parameterName parameter in $commandName has correct Mandatory value" {
+                    $codeMandatory = $parameter.IsMandatory.toString()
+                    $parameterHelp.Required | Should Be $codeMandatory
+                }
+
+                # Parameter type in Help should match code
+                # It "help for $commandName has correct parameter type for $parameterName" {
+                #     $codeType = $parameter.ParameterType.Name
+                #     # To avoid calling Trim method on a null object.
+                #     $helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
+                #     $helpType | Should be $codeType
+                # }
+            }
+
+            foreach ($helpParm in $HelpParameterNames) {
+                # Shouldn't find extra parameters in help.
+                It "finds help parameter in code: $helpParm" {
+                    $helpParm -in $parameterNames | Should Be $true
+                }
+            }
+        }
+
+        Context "Help Links should be Valid for $commandName" {
+            $link = $help.relatedLinks.navigationLink.uri
+
+            foreach ($link in $links) {
+                if ($link) {
+                    # Should have a valid uri if one is provided.
+                    it "[$link] should have 200 Status Code for $commandName" {
+                        $Results = Invoke-WebRequest -Uri $link -UseBasicParsing
+                        $Results.StatusCode | Should Be '200'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Manifest.tests.ps1
+++ b/tests/Manifest.tests.ps1
@@ -1,0 +1,91 @@
+
+$projectRoot = "$PSScriptRoot/.."
+$moduleName = 'psake'
+$manifestPath = "$PSScriptRoot/../psake.psd1"
+$manifest = Import-PowerShellDataFile -Path $manifestPath
+
+$changelogPath = Join-Path -Path $projectRoot -Child 'CHANGELOG.md'
+
+Describe 'Module manifest' {
+    Context 'Validation' {
+
+        $script:manifest = $null
+
+        It 'has a valid manifest' {
+            {
+                $script:manifest = Test-ModuleManifest -Path $manifestPath -Verbose:$false -ErrorAction Stop -WarningAction SilentlyContinue
+            } | Should Not Throw
+        }
+
+        It 'has a valid name in the manifest' {
+            $script:manifest.Name | Should Be $moduleName
+        }
+
+        It 'has a valid root module' {
+            $script:manifest.RootModule | Should Be "$($moduleName).psm1"
+        }
+
+        It 'has a valid version in the manifest' {
+            $script:manifest.Version -as [Version] | Should Not BeNullOrEmpty
+        }
+
+        It 'has a valid description' {
+            $script:manifest.Description | Should Not BeNullOrEmpty
+        }
+
+        It 'has a valid author' {
+            $script:manifest.Author | Should Not BeNullOrEmpty
+        }
+
+        It 'has a valid guid' {
+            {
+                [guid]::Parse($script:manifest.Guid)
+            } | Should Not throw
+        }
+
+        It 'has a valid copyright' {
+            $script:manifest.CopyRight | Should Not BeNullOrEmpty
+        }
+
+        # Only for DSC modules
+        # It 'exports DSC resources' {
+        #     $dscResources = ($Manifest.psobject.Properties | Where Name -eq 'ExportedDscResources').Value
+        #     @($dscResources).Count | Should Not Be 0
+        # }
+
+        $script:changelogVersion = $null
+        It 'has a valid version in the changelog' {
+            foreach ($line in (Get-Content $changelogPath)) {
+                if ($line -match "^##\s\[(?<Version>(\d+\.){1,3}\d+)\]") {
+                    $script:changelogVersion = $matches.Version
+                    break
+                }
+            }
+            $script:changelogVersion               | Should Not BeNullOrEmpty
+            $script:changelogVersion -as [Version] | Should Not BeNullOrEmpty
+        }
+
+        It 'changelog and manifest versions are the same' {
+            $script:changelogVersion -as [Version] | Should be ( $script:manifest.Version -as [Version] )
+        }
+
+        if (Get-Command git.exe -ErrorAction SilentlyContinue) {
+            $script:tagVersion = $null
+            It 'is tagged with a valid version' -skip {
+                $thisCommit = git.exe log --decorate --oneline HEAD~1..HEAD
+
+                if ($thisCommit -match 'tag:\s*(\d+(?:\.\d+)*)') {
+                    $script:tagVersion = $matches[1]
+                }
+
+                $script:tagVersion               | Should Not BeNullOrEmpty
+                $script:tagVersion -as [Version] | Should Not BeNullOrEmpty
+            }
+
+            It 'all versions are the same' {
+                $script:changelogVersion -as [Version] | Should be ( $script:manifest.Version -as [Version] )
+                #$script:manifest.Version -as [Version] | Should be ( $script:tagVersion -as [Version] )
+            }
+        }
+    }
+}

--- a/tests/Meta.Tests.ps1
+++ b/tests/Meta.Tests.ps1
@@ -1,0 +1,43 @@
+Set-StrictMode -Version latest
+
+$projectRoot = Resolve-Path -Path "$PSScriptRoot/.."
+if (-not $projectRoot) {
+    $projectRoot = $PSScriptRoot
+}
+
+# Make sure MetaFixers.psm1 is loaded - it contains Get-TextFilesList
+Import-Module -Name (Join-Path -Path $projectRoot -ChildPath 'tests/MetaFixers.psm1') -Verbose:$false -Force
+
+Describe 'Text files formatting' {
+
+    $allTextFiles = Get-TextFilesList $projectRoot
+
+    Context 'Files encoding' {
+        It "Doesn't use Unicode encoding" {
+            $unicodeFilesCount = 0
+            $allTextFiles | Foreach-Object {
+                if (Test-FileUnicode $_) {
+                    $unicodeFilesCount += 1
+                    Write-Warning "File $($_.FullName) contains 0x00 bytes. It's probably uses Unicode and need to be converted to UTF-8. Use Fixer 'Get-UnicodeFilesList `$pwd | ConvertTo-UTF8'."
+                }
+            }
+            $unicodeFilesCount | Should Be 0
+        }
+    }
+
+    Context 'Indentations' {
+        It 'Uses spaces for indentation, not tabs' {
+            $totalTabsCount = 0
+            $allTextFiles | Foreach-Object {
+                $fileName = $_.FullName
+                (Get-Content $_.FullName -Raw) | Select-String "`t" | Foreach-Object {
+                    Write-Warning "There are tab in $fileName. Use Fixer 'Get-TextFilesList `$pwd | ConvertTo-SpaceIndentation'."
+                    $totalTabsCount++
+                }
+            }
+            $totalTabsCount | Should Be 0
+        }
+    }
+}
+
+Remove-Module -Name MetaFixers

--- a/tests/MetaFixers.psm1
+++ b/tests/MetaFixers.psm1
@@ -1,0 +1,84 @@
+# Taken with love from https://github.com/PowerShell/DscResource.Tests/blob/master/MetaFixers.psm1
+
+<#
+    This module helps fix problems, found by Meta.Tests.ps1
+#>
+
+$ErrorActionPreference = 'stop'
+Set-StrictMode -Version latest
+
+function ConvertTo-UTF8()
+{
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
+        [System.IO.FileInfo]$fileInfo
+    )
+
+    process
+    {
+        $content = Get-Content -Raw -Encoding Unicode -Path $fileInfo.FullName
+        [System.IO.File]::WriteAllText($fileInfo.FullName, $content, [System.Text.Encoding]::UTF8)
+    }
+}
+
+function ConvertTo-SpaceIndentation()
+{
+    [CmdletBinding()]
+    [OutputType([void])]
+    param(
+        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
+        [System.IO.FileInfo]$fileInfo
+    )
+
+    process
+    {
+        $content = (Get-Content -Raw -Path $fileInfo.FullName) -replace "`t",'    '
+        [System.IO.File]::WriteAllText($fileInfo.FullName, $content)
+    }
+}
+
+function Get-TextFilesList
+{
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$root
+    )
+    ls -File -Recurse $root | ? { @('.gitignore', '.gitattributes', '.ps1', '.psm1', '.psd1', '.json', '.xml', '.cmd', '.mof') -contains $_.Extension }
+}
+
+function Test-FileUnicode
+{
+
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(ValueFromPipeline=$true, Mandatory=$true)]
+        [System.IO.FileInfo]$fileInfo
+    )
+
+    process
+    {
+
+        $path = $fileInfo.FullName
+        $bytes = [System.IO.File]::ReadAllBytes($path)
+        $zeroBytes = @($bytes -eq 0)
+        return [bool]$zeroBytes.Length
+
+    }
+}
+
+function Get-UnicodeFilesList()
+{
+    [CmdletBinding()]
+    [OutputType([System.IO.FileInfo])]
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$root
+    )
+
+    Get-TextFilesList $root | ? { Test-FileUnicode $_ }
+}

--- a/tests/integration/spec.tests.ps1
+++ b/tests/integration/spec.tests.ps1
@@ -1,0 +1,75 @@
+
+Remove-Module -Name psake -ErrorAction SilentlyContinue
+Import-Module -Name "$PSScriptRoot/../../psake.psm1"
+
+$psake.run_by_psake_build_tester = $true
+
+$buildFiles = Get-ChildItem $PSScriptRoot/../../specs/*.ps1
+$testResults = @()
+
+#$non_existant_buildfile = '' | Select-Object -Property Name, FullName
+#$non_existant_buildfile.Name = 'specifying_a_non_existant_buildfile_should_fail.ps1'
+#$non_existant_buildfile.FullName = 'c:\specifying_a_non_existant_buildfile_should_fail.ps1'
+#$buildFiles += $non_existant_buildfile
+
+describe 'PSake specs' {
+
+    function GetResult {
+        param(
+            [string]$FileName,
+            [bool]$BuildSucceeded
+        )
+
+        $shouldSucceed = $null
+
+        if ($FileName.EndsWith('_should_pass.ps1')) {
+            $shouldSucceed = $true
+        } elseif ($FileName.EndsWith('_should_fail.ps1')) {
+            $shouldSucceed = $false
+        } else {
+            throw "Invalid specification syntax. Specs should end with _should_pass or _should_fail. $FileName"
+        }
+
+        if ($BuildSucceeded -eq $shouldSucceed) {
+            'Passed'
+        } else {
+            'Failed'
+        }
+    }
+
+    $psakeParams = @{
+        Parameters = @{
+            p1 = 'v1'
+            p2 = 'v2'
+        }
+        Properties = @{
+            x = '1'
+            y = '2'
+        }
+        Initialization = {
+            if (-not $container) {
+                $container = @{}
+            }
+            $container.bar = 'bar'
+            $container.baz = 'baz'
+            $bar = 2
+            $baz = 3
+        }
+    }
+
+    foreach ($buildFile in $buildFiles) {
+        $testResult = '' | Select-Object -Property Name, Result
+        $testResult.Name = $buildFile.Name
+
+        it "$($buildFile.BaseName)" {
+
+            $psakeParams.BuildFile = $buildFile.FullName
+            Invoke-psake @psakeParams | Out-Null
+
+            $testResult.Result = GetResult -FileName $buildFile.Name -BuildSucceeded $psake.build_success
+            $testResult.Result | Should -Be 'Passed'
+        }
+    }
+}
+
+


### PR DESCRIPTION
## Description
This PR gets AppVeyor and Travis CI builds working and correctly passing success/failed status.

This also uses Pester to test the spec files and includes a handful of other Pester tests to check the quality of Get-Help against the public functions, the module manifest, spaces vs tabs, etc.

https://ci.appveyor.com/project/psake/psake/build/4.6.0.103
https://travis-ci.org/psake/psake/jobs/298409461
https://travis-ci.org/psake/psake/jobs/298409462

## Related Issue
#172 

## Motivation and Context
Get AppVeyor and Travis executing tests correctly.

## How Has This Been Tested?
Modified `appveyor.yml` and `.travis.yml` to execute a common `build.ps1` script. This build script will handle installing dotnet and kicking off the Pester tests.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
