### PR TITLE
Ensure postAction and taskTeardown tasks get called after action failure

### DIFF
--- a/specs/postAction_runs_on_failed_should_fail.ps1
+++ b/specs/postAction_runs_on_failed_should_fail.ps1
@@ -1,0 +1,13 @@
+task default -depends Test
+
+task Test -depends Compile, Clean -PreAction {"Pre-Test"} -Action {
+    Assert $false "This fails."
+} -PostAction {"Post-Test"}
+
+task Compile -depends Clean {
+    "Compile"
+}
+
+task Clean {
+    "Clean"
+}

--- a/specs/taskTearDown_runs_on_failed_test_should_fail.ps1
+++ b/specs/taskTearDown_runs_on_failed_test_should_fail.ps1
@@ -1,0 +1,17 @@
+task default -depends Test
+
+task Test -depends Compile, Clean {
+    Assert $false "This fails."
+}
+
+task Compile -depends Clean {
+    "Compile"
+}
+
+task Clean {
+    "Clean"
+}
+
+taskTearDown {
+    "$($psake.context.Peek().currentTaskName) Tear Down"
+}


### PR DESCRIPTION
## Description
Replacement for old PR #74. This change ensures that if `postAction` or `taskTearDown` tasks are defined, they will always be called.

From @stephan-dowding in #74:
> A quick patch to fix a little bug bear of mine...
I normally expect things like PostAction and TearDown to be called even if the main Action has failed. This is because it is natural for me to use things like PreAction and SetUp to reserve resources and setup the environment for the Action. I will then use PostAction and TearDown to release those resources and wind down the environment. Having all that stuff hanging around after a test failure was extremely annoying!
I know I could have used try...finally within my Action blocks, but these constructs felt like the natural and intended place for them, hence the pull request!

## Related Issue
N/A

## Motivation and Context
PostAction and TaskTeardown tasks should get called regardless of the main action succeeding or not.

## How Has This Been Tested?
Ran through specs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
