### PR TITLE
Bump version to v4.7.0 and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.7.0] Unreleased
+## [4.7.0] 2017-11-21
+
+As part of this release we had [13 issues](https://github.com/psake/psake/issues?q=milestone%3Av4.7.0+is%3Aclosed) closed.
 
 ### Features
 
-- [**196**](https://github.com/psake/psake/pull/196) Deprecate default build script name `default.ps1` in favor of `psakefile.ps1`. (via [@glennsarti](https://github.com/glennsarti))
+- [**#198**](https://github.com/psake/psake/pull/198) Add support for PowerShell Core on macOS and Linux. (via [@dbroeglin](https://github.com/dbroeglin))
+
+- [**#196**](https://github.com/psake/psake/pull/196) Deprecate default build script name `default.ps1` in favor of `psakefile.ps1`. (via [@glennsarti](https://github.com/glennsarti))
+
+- Remove legacy PowerShell v2 support. PSake now supports v3 and above.
 
 ### Improvements
 
-- [**222**](https://github.com/psake/psake/pull/222) Add support for .Net frameworks 4.6.2, 4.7, and 4.7.1. (via [@rkeithhill](https://github.com/rkeithhill))
+- [**#228**](https://github.com/psake/psake/pull/228) Project structure refactor (via [@devblackops](https://github.com/devblackops))
 
-- [**218**](https://github.com/psake/psake/pull/218) Improve Build Time Report by using custom `FormatTaskName` value for header and display task timing at millisecond accuracy instead of microsecond. (via [@theunrepentantgeek](https://github.com/theunrepentantgeek))
+- [**#227**](https://github.com/psake/psake/pull/227) Ensure postAction and taskTeardown tasks get called after action failure (via [@stephan-dowding](https://github.com/stephan-dowding))
 
-- [**198**](https://github.com/psake/psake/pull/198) Add support for PowerShell Core on macOS and Linux. (via [@dbroeglin](https://github.com/dbroeglin))
+- [**#222**](https://github.com/psake/psake/pull/222) Add support for .Net frameworks 4.6.2, 4.7, and 4.7.1. (via [@rkeithhill](https://github.com/rkeithhill))
 
-- [**190**](https://github.com/psake/psake/pull/190) Use `WriteColoredOutput` for all task headers. (via [@damianpowell](https://github.com/damianpowell))
+- [**#218**](https://github.com/psake/psake/pull/218) Improve Build Time Report by using custom `FormatTaskName` value for header and display task timing at millisecond accuracy instead of microsecond. (via [@theunrepentantgeek](https://github.com/theunrepentantgeek))
+
+- [**#200**](https://github.com/psake/psake/pull/200) Add `WorkingDirectory` parameter to `Exec` function. (via [@DaveSenn](https://github.com/DaveSenn))
+
+- [**#190**](https://github.com/psake/psake/pull/190) Use `WriteColoredOutput` for all task headers. (via [@damianpowell](https://github.com/damianpowell))
 
 ## [4.6.0] 2016-03-20
 

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'psake.psm1'
-    ModuleVersion     = '4.6.0'
+    ModuleVersion     = '4.7.0'
     GUID              = 'cfb53216-072f-4a46-8975-ff7e6bda05a5'
     Author            = 'James Kovacs'
     Copyright         = 'Copyright (c) 2012-16 James Kovacs, Damian Hickey and Contributors'

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -3,7 +3,7 @@
     ModuleVersion     = '4.7.0'
     GUID              = 'cfb53216-072f-4a46-8975-ff7e6bda05a5'
     Author            = 'James Kovacs'
-    Copyright         = 'Copyright (c) 2012-16 James Kovacs, Damian Hickey and Contributors'
+    Copyright         = 'Copyright (c) 2010-17 James Kovacs, Damian Hickey and Contributors'
     PowerShellVersion = '3.0'
     Description       = 'psake is a build automation tool written in PowerShell.'
     FunctionsToExport = @('Invoke-psake',

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -238,7 +238,7 @@ function Invoke-psake {
 
     try {
         if (-not $nologo) {
-            "psake version {0}`nCopyright (c) 2010-2014 James Kovacs & Contributors`n" -f $psake.version
+            "psake version {0}`nCopyright (c) 2010-2017 James Kovacs & Contributors`n" -f $psake.version
         }
         if (!$buildFile) {
            $buildFile = Get-DefaultBuildFile


### PR DESCRIPTION
## Description
Bump module version to `v4.7.0` and update changelog to reflect the highlights since the last release.

## Related Issue
#225 
#217 
#197 

## Motivation and Context
Release a version of PSake that works on macOS/Linux.

## How Has This Been Tested?
AppVeyor / Travis

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
