### PR TITLE
Add Travis CI matrix for improved job tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ language: cpp
 git:
   depth: 1000
 
-os:
-  - linux
-  - osx
-sudo: required
-dist: trusty
-osx_image: xcode8.3
+matrix:
+    include:
+        - os: linux
+          dist: trusty
+          sudo: required
+        - os: osx
+          osx_image: xcode8.3
 
 install:
   - pushd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ git:
   depth: 1000
 
 matrix:
-    include:
-        - os: linux
-          dist: trusty
-          sudo: required
-        - os: osx
-          osx_image: xcode8.3
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: osx
+      osx_image: xcode8.3
 
 install:
   - pushd build


### PR DESCRIPTION
Defined a Travis CI matrix in the .travis.yml config file to remove the xcode tag from future Ubuntu Trusty jobs.

## Description
Added a Travis CI job matrix to improve definition between macOS and Ubunty Trusty jobs as I learned in my own project: https://github.com/tlindsay42/ArmorPowerShell/blob/master/.travis.yml

## Related Issue
#231 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes the xcode tag for Ubuntu Trusty Travis CI jobs.

## How Has This Been Tested?
Figured this out last month in my Armor PowerShell Module project.  Example: https://travis-ci.org/tlindsay42/ArmorPowerShell/builds/305173326

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/11078689/33110515-f99d615a-cf0d-11e7-95bc-e19678b956e1.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
