### PR TITLE
Fix most PSSA warnings - suppressed a few.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ install:
 
 script:
   - ulimit -n 4096
-  - pwsh -file build.ps1
+  - pwsh -noprofile -nologo -command \$PSVersionTable
+  - pwsh -noprofile -nologo -file build.ps1

--- a/specs/detailedDocs_should_pass.ps1
+++ b/specs/detailedDocs_should_pass.ps1
@@ -2,11 +2,9 @@
 Task default -depends CheckDetailedDocs
 
 Task CheckDetailedDocs {
-
-    $docArray = (Invoke-psake .\nested\docs.ps1 -detailedDocs -nologo | Out-String).Split("`n")
-    $docString = (($docArray | Foreach-Object {
-        $_.Trim()
-    }) -join "`n").Trim()
+    $NL = [System.Environment]::NewLine
+    $docArray = @(Invoke-psake .\nested\docs.ps1 -detailedDocs -nologo | Out-String -Stream -Width 120)
+    $docString = (($docArray | Foreach-Object Trim) -join $NL).Trim()
 
     $expectedDoc = @"
 Name        : Compile
@@ -44,11 +42,9 @@ Alias       : ut
 Description :
 Depends On  :
 Default     :
-"@
-    $expectedDoc = $expectedDoc.Split("`n")
-    $expectedDocString = (($expectedDoc | Foreach-Object {
-        $_.Trim()
-    }) -join "`n").Trim()
+"@ -split $NL
 
-    Assert ($docString -eq $expectedDocString) "Unexpected simple doc: $doc"
+    $expectedDocString = (($expectedDoc | Foreach-Object Trim) -join $NL).Trim()
+
+    Assert ($docString -eq $expectedDocString) "Unexpected simple doc: $docString"
 }

--- a/specs/docs_should_pass.ps1
+++ b/specs/docs_should_pass.ps1
@@ -2,11 +2,9 @@
 Task default -depends CheckDocs
 
 Task CheckDocs {
-
-    $docArray = (Invoke-psake .\nested\docs.ps1 -docs -nologo | Out-String).Split("`n")
-    $docString = (($docArray | Foreach-Object {
-        $_.Trim()
-    }) -join "`n").Trim()
+    $NL = [System.Environment]::NewLine
+    $docArray = @(Invoke-psake .\nested\docs.ps1 -docs -nologo | Out-String -Stream -Width 120)
+    $docString = (($docArray | Foreach-Object Trim) -join $NL).Trim()
 
     $expectedDoc = @"
 Name             Alias Depends On                         Default Description
@@ -17,11 +15,9 @@ CompileSolutionB
 IntegrationTests
 Test                   UnitTests, IntegrationTests           True
 UnitTests        ut
-"@
-    $expectedDoc = $expectedDoc.Split("`n")
-    $expectedDocString = (($expectedDoc | Foreach-Object {
-        $_.Trim()
-    }) -join "`n").Trim()
+"@ -split $NL
 
-    Assert ($docString -eq $expectedDocString) "Unexpected simple doc: $doc"
+    $expectedDocString = (($expectedDoc | Foreach-Object Trim) -join $NL).Trim()
+
+    Assert ($docString -eq $expectedDocString) "Unexpected simple doc: $docString"
 }

--- a/specs/prefer_default_buildfile_over_legacy_should_pass.ps1
+++ b/specs/prefer_default_buildfile_over_legacy_should_pass.ps1
@@ -3,9 +3,9 @@ task default -depends test
 task test {
     # This test fixture has both a default and legacy default build file.
     # In this case the default buildfile should be used in preference to legacy
-    
+
     Push-Location 'legacy_and_default_build_file'
-    $result = invoke-psake -Docs | Out-String
+    $result = invoke-psake -Docs | Out-String -Width 120
     Pop-Location
 
     Assert ($result -match 'adefaulttask') 'Default build file should a task called adefaulttask'

--- a/specs/use_default_buildfile_should_pass.ps1
+++ b/specs/use_default_buildfile_should_pass.ps1
@@ -4,7 +4,7 @@ task test {
     # This test fixture has a default build file.
 
     Push-Location 'default_build_file'
-    $result = invoke-psake -Docs | Out-String
+    $result = invoke-psake -Docs | Out-String -Width 120
     Pop-Location
 
     Assert ($result -match 'adefaulttask') 'Default build file should a task called adefaulttask'

--- a/specs/use_legacy_default_buildfile_should_pass.ps1
+++ b/specs/use_legacy_default_buildfile_should_pass.ps1
@@ -4,7 +4,7 @@ task test {
     # This test fixture has a legacy default build file.
 
     Push-Location 'legacy_build_file'
-    $result = invoke-psake -Docs | Out-String
+    $result = invoke-psake -Docs | Out-String -Width 120
     Pop-Location
 
     Assert ($result -match 'alegacydefaulttask') 'Default build file should a task called alegacydefaulttask'

--- a/src/private/CleanupEnvironment.ps1
+++ b/src/private/CleanupEnvironment.ps1
@@ -1,7 +1,8 @@
 function CleanupEnvironment {
     if ($psake.context.Count -gt 0) {
         $currentContext = $psake.context.Peek()
-        $env:path = $currentContext.originalEnvPath
+        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+        $env:PATH = $currentContext.originalEnvPath
         Set-Location $currentContext.originalDirectory
         $global:ErrorActionPreference = $currentContext.originalErrorActionPreference
         [void] $psake.context.Pop()

--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -88,10 +88,10 @@ function ConfigureBuildEnvironment {
         }
 
         $frameworkDirs = @()
-        if ($buildToolsVersions -ne $null) {
+        if ($null -ne $buildToolsVersions) {
             foreach($ver in $buildToolsVersions) {
                 if ($ver -eq "15.0") {
-                    if ((Get-Module -Name VSSetup -ListAvailable) -eq $null) {
+                    if ($null -eq (Get-Module -Name VSSetup -ListAvailable)) {
                         WriteColoredOutput ($msgs.warning_missing_vsssetup_module -f $ver) -foregroundcolor Yellow
                         continue
                     }

--- a/src/private/ExecuteInBuildFileScope.ps1
+++ b/src/private/ExecuteInBuildFileScope.ps1
@@ -13,7 +13,7 @@ function ExecuteInBuildFileScope {
         "taskTearDownScriptBlock" = {};
         "executedTasks" = new-object System.Collections.Stack;
         "callStack" = new-object System.Collections.Stack;
-        "originalEnvPath" = $env:path;
+        "originalEnvPath" = $env:PATH;
         "originalDirectory" = get-location;
         "originalErrorActionPreference" = $global:ErrorActionPreference;
         "tasks" = @{};

--- a/src/private/LoadConfiguration.ps1
+++ b/src/private/LoadConfiguration.ps1
@@ -3,10 +3,11 @@ function LoadConfiguration {
         [string] $configdir = $PSScriptRoot
     )
 
-    $psakeConfigFilePath = (join-path $configdir "psake-config.ps1")
+    $psakeConfigFilePath = (Join-Path $configdir "psake-config.ps1")
 
     if (test-path $psakeConfigFilePath -pathType Leaf) {
         try {
+            [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
             $config = GetCurrentConfigurationOrDefault
             . $psakeConfigFilePath
         } catch {

--- a/src/private/LoadModules.ps1
+++ b/src/private/LoadModules.ps1
@@ -6,15 +6,16 @@ function LoadModules {
 
         $global = [string]::Equals($scope, "global", [StringComparison]::CurrentCultureIgnoreCase)
 
-        $currentConfig.modules | foreach {
-            resolve-path $_ | foreach {
+        $currentConfig.modules | ForEach-Object {
+            resolve-path $_ | ForEach-Object {
                 "Loading module: $_"
-                $module = import-module $_ -passthru -DisableNameChecking -global:$global
+                $module = Import-Module $_ -passthru -DisableNameChecking -global:$global
                 if (!$module) {
                     throw ($msgs.error_loading_module -f $_.Name)
                 }
             }
         }
+
         ""
     }
 }

--- a/src/private/ResolveError.ps1
+++ b/src/private/ResolveError.ps1
@@ -21,7 +21,7 @@ function ResolveError
             $formatted_exception = ''
 
             $i = 0
-            while ($ex -ne $null) {
+            while ($null -ne $ex) {
                 $i++
                 $formatted_exception += ("$i" * 70) + "`n" +
                     ($ex | format-list * -force | out-string) + "`n"
@@ -32,7 +32,7 @@ function ResolveError
         }
 
         $lastException = @()
-        while ($ex -ne $null) {
+        while ($null -ne $ex) {
             $lastMessage = $ex | SelectObjectWithDefault -Name 'Message' -Value ''
             $lastException += ($lastMessage -replace "`n", '')
             if ($ex -is [Data.SqlClient.SqlException]) {
@@ -45,13 +45,12 @@ function ResolveError
         $shortException = $lastException -join ' --> '
 
         $header = $null
-        $current = $_
         $header = (($_.InvocationInfo |
             SelectObjectWithDefault -Name 'PositionMessage' -Value '') -replace "`n", ' '),
             ($_ | SelectObjectWithDefault -Name 'Message' -Value ''),
             ($_ | SelectObjectWithDefault -Name 'Exception' -Value '') |
-                ? { -not [String]::IsNullOrEmpty($_) } |
-                Select -First 1
+                Where-Object { -not [String]::IsNullOrEmpty($_) } |
+                Select-Object -First 1
 
         $delimiter = ''
         if ((-not [String]::IsNullOrEmpty($header)) -and

--- a/src/private/WriteColoredOutput.ps1
+++ b/src/private/WriteColoredOutput.ps1
@@ -6,7 +6,7 @@ function WriteColoredOutput {
 
     $currentConfig = GetCurrentConfigurationOrDefault
     if ($currentConfig.coloredOutput -eq $true) {
-        if (($Host.UI -ne $null) -and ($Host.UI.RawUI -ne $null) -and ($Host.UI.RawUI.ForegroundColor -ne $null)) {
+        if (($null -ne $Host.UI) -and ($null -ne $Host.UI.RawUI) -and ($null -ne $Host.UI.RawUI.ForegroundColor)) {
             $previousColor = $Host.UI.RawUI.ForegroundColor
             $Host.UI.RawUI.ForegroundColor = $foregroundcolor
         }
@@ -14,7 +14,7 @@ function WriteColoredOutput {
 
     $message
 
-    if ($previousColor -ne $null) {
+    if ($null -ne $previousColor) {
         $Host.UI.RawUI.ForegroundColor = $previousColor
     }
 }

--- a/src/private/WriteDocumentation.ps1
+++ b/src/private/WriteDocumentation.ps1
@@ -9,8 +9,8 @@ function WriteDocumentation($showDetailed) {
         }
 
         $docs = GetTasksFromContext $currentContext |
-                    Where   {$_.Name -ne 'default'} |
-                    ForEach {
+                    Where-Object   {$_.Name -ne 'default'} |
+                    ForEach-Object {
                         $isDefault = $null
                         if ($defaultTaskDependencies -contains $_.Name) {
                             $isDefault = $true

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -93,7 +93,7 @@ function Exec {
                 }
             }
 
-            Write-Host "Try $tryCount failed, retrying again in 1 second..."
+            "Try $tryCount failed, retrying again in 1 second..."
 
             $tryCount++
 

--- a/src/public/Get-PSakeScriptTasks.ps1
+++ b/src/public/Get-PSakeScriptTasks.ps1
@@ -24,6 +24,7 @@ function Get-PSakeScriptTasks {
     .LINK
     Invoke-psake
     #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
         [string]$buildFile

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -72,7 +72,7 @@ function Invoke-Task {
         if ($taskKey -ne 'default') {
 
             if ($task.PreAction -or $task.PostAction) {
-                Assert ($task.Action -ne $null) ($msgs.error_missing_action_parameter -f $taskName)
+                Assert ($null -ne $task.Action) ($msgs.error_missing_action_parameter -f $taskName)
             }
 
             if ($task.Action) {
@@ -101,7 +101,7 @@ function Invoke-Task {
                             WriteColoredOutput $taskHeader -foregroundcolor Cyan
 
                             foreach ($variable in $task.requiredVariables) {
-                                Assert ((test-path "variable:$variable") -and ((get-variable $variable).Value -ne $null)) ($msgs.required_variable_not_set -f $variable, $taskName)
+                                Assert ((Test-Path "variable:$variable") -and ($null -ne (Get-Variable $variable).Value)) ($msgs.required_variable_not_set -f $variable, $taskName)
                             }
 
                             & $task.Action

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -243,7 +243,7 @@ function Invoke-psake {
         if (!$buildFile) {
            $buildFile = Get-DefaultBuildFile
         }
-        elseif (!(test-path $buildFile -pathType Leaf) -and ((Get-DefaultBuildFile -UseDefaultIfNoneExist $false) -ne $null) ) {
+        elseif (!(Test-Path $buildFile -PathType Leaf) -and ($null -ne (Get-DefaultBuildFile -UseDefaultIfNoneExist $false))) {
             # If the default file exists and the given "buildfile" isn't found assume that the given
             # $buildFile is actually the target Tasks to execute in the $config.buildFileName script.
             $taskList = $buildFile.Split(', ')

--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -122,7 +122,7 @@ function Task {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$name = $null,
+        [string]$name,
 
         [scriptblock]$action = $null,
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix PS ScriptAnalyzer warnings. There should be zero warnings now.

Also normalized casing on $env:path to $env:PATH because on *nix systems env var is upper case.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Broken window theory - if we have too many PSSA warnings they will just be ignored.  By getting to zero it becomes more obvious when new warnings are introduced.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all the Pester tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure improvement.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
