### PR TITLE
Document dependence on VSSetup module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you wish to use the psake command from outside of the install folder, add the
 
 **Step 5: (With VS2017)** Install the VSSetup dependency
 
-Psake uses [VSSetup](https://blogs.msdn.microsoft.com/heaths/2017/01/25/visual-studio-setup-powershell-module-available/) to locate msbuild when using Visual Studio 2017.  The VSSetup PowerShell module must be installed prior to compiling a VS2017 project with psake.  Install instructions for VSSetup can be found [here](https://github.com/Microsoft/vssetup.powershell#installing) and [here](https://www.powershellgallery.com/packages/VSSetup).
+psake uses [VSSetup](https://blogs.msdn.microsoft.com/heaths/2017/01/25/visual-studio-setup-powershell-module-available/) to locate msbuild when using Visual Studio 2017.  The VSSetup PowerShell module must be installed prior to compiling a VS2017 project with psake.  Install instructions for VSSetup can be found [here](https://github.com/Microsoft/vssetup.powershell#installing) and [here](https://www.powershellgallery.com/packages/VSSetup).
 
 ## Release Notes
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you encounter the following error "Import-Module : ...psake.psm1 cannot be lo
 
 If you wish to use the psake command from outside of the install folder, add the folder install directory to your PATH variable.
 
+**Step 5: (With VS2017)** Install the VSSetup dependency
+
+Psake uses [VSSetup](https://blogs.msdn.microsoft.com/heaths/2017/01/25/visual-studio-setup-powershell-module-available/) to locate msbuild when using Visual Studio 2017.  The VSSetup PowerShell module must be installed prior to compiling a VS2017 project with psake.  Install instructions for VSSetup can be found [here](https://github.com/Microsoft/vssetup.powershell#installing) and [here](https://www.powershellgallery.com/packages/VSSetup).
+
 ## Release Notes
 
 You can find all the information about each release of psake in the [releases section](https://github.com/psake/psake/releases).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add another step to the install instructions in the readme for VS2017 builds.

## Related Issue
Proposing a documentation updated.

## Motivation and Context
I'd actually prefer that we internalize the VSSetup dependency within psake itself to avoid taking an additional installation dependency.  But that which I do not have time to fix, I must document.

## How Has This Been Tested?
I have installed VSSetup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
