### PR TITLE
Remove Cmdlet aliases

### DIFF
--- a/tabexpansion/PsakeTabExpansion.ps1
+++ b/tabexpansion/PsakeTabExpansion.ps1
@@ -1,16 +1,16 @@
 $global:psakeSwitches = @('-docs', '-task', '-properties', '-parameters')
 
 function script:psakeSwitches($filter) {  
-  $psakeSwitches | where { $_ -like "$filter*" }
+  $psakeSwitches | Where-Object { $_ -like "$filter*" }
 }
 
 function script:psakeDocs($filter, $file) {
   if ($file -eq $null -or $file -eq '') { $file = 'psakefile.ps1' }
-  psake $file -docs | out-string -Stream |% { if ($_ -match "^[^ ]*") { $matches[0]} } |? { $_ -ne "Name" -and $_ -ne "----" -and $_ -like "$filter*" }
+  psake $file -docs | out-string -Stream | ForEach-Object { if ($_ -match "^[^ ]*") { $matches[0]} } | Where-Object { $_ -ne "Name" -and $_ -ne "----" -and $_ -like "$filter*" }
 }
 
 function script:psakeFiles($filter) {
-    ls "$filter*.ps1" |% { $_.Name }
+    Get-ChildItem "$filter*.ps1" | ForEach-Object { $_.Name }
 }
 
 function PsakeTabExpansion($lastBlock) {
@@ -25,7 +25,7 @@ function PsakeTabExpansion($lastBlock) {
       @(psakeDocs $matches[3] $matches[2]) + @(psakeSwitches $matches[3]) | Sort-Object
     }
     '(invoke-psake|psake) (\S*)$' {
-      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'psakefile.ps1') + @(psakeSwitches $matches[2]) | sort
+      @(psakeFiles $matches[2]) + @(psakeDocs $matches[2] 'psakefile.ps1') + @(psakeSwitches $matches[2]) | Sort-Object
     }
   }
 }


### PR DESCRIPTION
## Description

Remove cmdlet aliases.

## Motivation and Context
PSScriptAnalyzer warning ['PSAvoidUsingCmdletAliases'](https://github.com/PowerShell/PSScriptAnalyzer/blob/development/RuleDocumentation/AvoidUsingCmdletAliases.md).

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
