### PR TITLE
Fix #246. Load psake-config.ps1 from correct path in module folder.

### DIFF
--- a/src/private/LoadConfiguration.ps1
+++ b/src/private/LoadConfiguration.ps1
@@ -13,10 +13,12 @@ function LoadConfiguration {
     $configFilePath  = Join-Path -Path $configdir -ChildPath $script:psakeConfigFile
     $defaultConfigFilePath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath $script:psakeConfigFile
 
-    if (Test-Path -Path $configFilePath -PathType Leaf) {
+    if (Test-Path -LiteralPath $configFilePath -PathType Leaf) {
         $configFileToLoad = $configFilePath
-    } elseIf (Test-Path -Path $defaultConfigFilePath -PathType Leaf) {
+    } elseIf (Test-Path -LiteralPath $defaultConfigFilePath -PathType Leaf) {
         $configFileToLoad = $defaultConfigFilePath
+    } else {
+        throw 'Cannot find psake-config.ps1'
     }
 
     try {

--- a/src/private/LoadConfiguration.ps1
+++ b/src/private/LoadConfiguration.ps1
@@ -1,17 +1,29 @@
 function LoadConfiguration {
+    <#
+    .SYNOPSIS
+    Load psake-config.ps1 file
+    .DESCRIPTION
+    Load psake-config.ps1 if present in the directory of the current build script.
+    If that file doesn't exist, load the default psake-config.ps1 file from the module directory.
+    #>
     param(
-        [string] $configdir = $PSScriptRoot
+        [string]$configdir = (Split-Path -Path $PSScriptRoot -Parent)
     )
 
-    $psakeConfigFilePath = (Join-Path $configdir "psake-config.ps1")
+    $configFilePath  = Join-Path -Path $configdir -ChildPath $script:psakeConfigFile
+    $defaultConfigFilePath = Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -ChildPath $script:psakeConfigFile
 
-    if (test-path $psakeConfigFilePath -pathType Leaf) {
-        try {
-            [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
-            $config = GetCurrentConfigurationOrDefault
-            . $psakeConfigFilePath
-        } catch {
-            throw "Error Loading Configuration from psake-config.ps1: " + $_
-        }
+    if (Test-Path -Path $configFilePath -PathType Leaf) {
+        $configFileToLoad = $configFilePath
+    } elseIf (Test-Path -Path $defaultConfigFilePath -PathType Leaf) {
+        $configFileToLoad = $defaultConfigFilePath
+    }
+
+    try {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssigments', '')]
+        $config = GetCurrentConfigurationOrDefault
+        . $configFileToLoad
+    } catch {
+        throw 'Error Loading Configuration from {0}: {1}' -f $configFileToLoad, $_
     }
 }

--- a/src/psake.psm1
+++ b/src/psake.psm1
@@ -77,6 +77,8 @@ $scriptDir = Split-Path $MyInvocation.MyCommand.Path
 $manifestPath = Join-Path $scriptDir psake.psd1
 $manifest = Test-ModuleManifest -Path $manifestPath -WarningAction SilentlyContinue
 
+$script:psakeConfigFile = 'psake-config.ps1'
+
 $script:psake = @{}
 
 $psake.version = $manifest.Version.ToString()


### PR DESCRIPTION
## Description
The default psake-config.ps1 path was incorrect and probably broke with #228. This prevented the default config file from being loaded when a psake-config.ps1 file was not present in the current build script directory.

## Related Issue
#246 

## Motivation and Context
The default `psake-config.ps1` file should be loaded if not present in the current build script directory.

## How Has This Been Tested?
Made changes to default `psake-config.ps1` file in module folder and validated those changes where executed. Also created `psake-config.ps1` file in same directory as build script and validated those changes take precedence over the default config file.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
