### PR TITLE
Allow working with preloaded VSSetup module

### DIFF
--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -91,12 +91,14 @@ function ConfigureBuildEnvironment {
         if ($null -ne $buildToolsVersions) {
             foreach($ver in $buildToolsVersions) {
                 if ($ver -eq "15.0") {
-                    if ($null -eq (Get-Module -Name VSSetup -ListAvailable)) {
-                        WriteColoredOutput ($msgs.warning_missing_vsssetup_module -f $ver) -foregroundcolor Yellow
-                        continue
-                    }
+                    if ($null -eq (Get-Module -Name VSSetup)) {
+                        if ($null -eq (Get-Module -Name VSSetup -ListAvailable)) {
+                            WriteColoredOutput ($msgs.warning_missing_vsssetup_module -f $ver) -foregroundcolor Yellow
+                            continue
+                        }
 
-                    Import-Module VSSetup
+                        Import-Module VSSetup
+                    }
 
                     # borrowed from nightroman https://github.com/nightroman/Invoke-Build
                     if ($vsInstances = Get-VSSetupInstance) {


### PR DESCRIPTION
## Description
Current implementation required VSSetup module to be installed in location where PowerShell can find it automatically. Now, before trying to import VSSetup, psake will check if it's not already loaded. This allows to work with VSSetup committed to repository, loading it either by psake-config.ps1 or manually in helper script.

## Related Issue
Somewhat fixes #241, because now you don't have to install and maintain additional modules on build servers.

## Motivation and Context
It's not always feasible to install additional modules on build server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did not have VSSetup module installed. I have copied VSSetup module to a folder in repository. Then I modified psake-config.ps1 to include VSSetup.psd1 in $config.modules. After this psake used MSBuild 15 and build succeeded, whereas before the change it used version 14.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
