### PR TITLE
fix #169 how-to-fail-a-build docs

### DIFF
--- a/docs/how-to-fail-a-build.md
+++ b/docs/how-to-fail-a-build.md
@@ -53,4 +53,10 @@ The following is an example:
 
 ```powershell
 task default -depends TaskA
+
+task TaskA {
+  #use cmd.exe and the DOS exit() function to simulate a failed command-line execution
+  "Executing command-line program"
+  exec { cmd /c exit (1) }
+}
 ```


### PR DESCRIPTION
This fixes the documentation issue in #169

## Description
Updates the /docs/how-to-fail-a-build.md

## Related Issue
#169 

## Motivation and Context
simple change, open issue, fix identified in the original issue

## How Has This Been Tested?
no testing done

## Screenshots (if appropriate):
n/a

## Types of changes
documentation change only

## Checklist:
not applicable
