### PR TITLE
Adding support for .net 4.7.2

### DIFF
--- a/specs/dotNet4.7.2_should_pass.ps1
+++ b/specs/dotNet4.7.2_should_pass.ps1
@@ -1,0 +1,10 @@
+
+Framework "4.7.2"
+ task default -depends MsBuild
+ task MsBuild {
+    if ( $IsMacOS -OR $IsLinux ) {}
+    else {
+        $output = &msbuild /version /nologo 2>&1
+        Assert ($output -NotLike "15.0") '$output should contain 15.0'
+    }
+}

--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -44,7 +44,7 @@ function ConfigureBuildEnvironment {
                 $versions = @('v4.0.30319')
                 $buildToolsVersions = @('15.0', '14.0')
             }
-            {($_ -eq '4.7') -or ($_ -eq '4.7.1')} {
+            {($_ -eq '4.7') -or ($_ -eq '4.7.1') -or ($_ -eq '4.7.2')} {
                 $versions = @('v4.0.30319')
                 $buildToolsVersions = @('15.0')
             }


### PR DESCRIPTION

## Description
Added .net 4.7.2 to ConfigureBuildEnvironment.ps1, with only build tools 15.0
this follows the same patter already implemented for .net 4.7 and .net 4.7.2

## Related Issue
#256

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
ci/cd tests are passing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
