### PR TITLE
(GH119) add $psake.error_message

### DIFF
--- a/src/psake.psm1
+++ b/src/psake.psm1
@@ -98,6 +98,7 @@ $psake.config_default = new-object psobject -property @{
 $psake.build_success = $false # indicates that the current build was successful
 $psake.build_script_file = $null # contains a System.IO.FileInfo for the current build script
 $psake.build_script_dir = "" # contains a string with fully-qualified path to current build script
+$psake.error_message = $null # contains the error message which caused the script to fail
 
 LoadConfiguration
 

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -129,6 +129,7 @@ function Invoke-psake {
         $psake.build_success                # indicates that the current build was successful
         $psake.build_script_file            # contains a System.IO.FileInfo for the current build script
         $psake.build_script_dir             # contains the fully qualified path to the current build script
+        $psake.error_message                # contains the error message which caused the script to fail
 
         You should see the following when you display the contents of the $psake variable right after importing psake
 
@@ -144,6 +145,7 @@ function Invoke-psake {
         build_script_dir
         config_default                 @{framework=3.5; ...
         context                        {}
+        error_message
 
         After a build is executed the following $psake values are updated: build_script_file, build_script_dir, build_success
 
@@ -178,6 +180,7 @@ function Invoke-psake {
         version                        4.2
         build_success                  True
         config_default                 @{framework=3.5; ...
+        error_message
 
         .LINK
         Assert
@@ -296,6 +299,7 @@ function Invoke-psake {
 
             $successMsg = $msgs.psake_success -f $buildFile
             WriteColoredOutput ("`n${successMsg}`n") -foregroundcolor Green
+            $psake.error_message = $null
 
             $stopwatch.Stop()
             if (-not $notr) {
@@ -323,6 +327,7 @@ function Invoke-psake {
         }
 
         $psake.build_success = $false
+        $psake.error_message = $error_message
 
         # if we are running in a nested scope (i.e. running a psake script from a psake script) then we need to re-throw the exception
         # so that the parent script will fail otherwise the parent script will report a successful build

--- a/tests/integration/spec.tests.ps1
+++ b/tests/integration/spec.tests.ps1
@@ -39,17 +39,25 @@ describe 'PSake specs' {
         it "$($buildFile.BaseName)" {
 
             $psakeParams.BuildFile = $buildFile.FullName
+            $shouldHaveError = $false
 
             if ($buildFile.Name.EndsWith('_should_pass.ps1')) {
                 $expectedResult = $true
             } elseif ($buildFile.Name.EndsWith('_should_fail.ps1')) {
                 $expectedResult = $false
+                $shouldHaveError = $true
             } else {
                 throw "Invalid specification syntax. Specs file [$($buildFile.BaseName)] should end with _should_pass or _should_fail."
             }
 
             Invoke-psake @psakeParams | Out-Null
             $psake.build_success | should -be $expectedResult
+           
+            if ($shouldHaveError) {
+               $psake.error_message | should -not -be $null
+            } else {
+               $psake.error_message | should -be $null
+            }
         }
     }
 }


### PR DESCRIPTION
Adding $psake.error_message per #119

## Related Issue
#119

## How Has This Been Tested?
Added $psake.error_messge pester check to current tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
