### PR TITLE
(GH258) Change duration to be per task instead of cumulative

### DIFF
--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -77,12 +77,13 @@ function Invoke-Task {
 
             if ($task.Action) {
 
-                $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+                $stopwatch = new-object System.Diagnostics.Stopwatch
 
                 try {
                     foreach($childTask in $task.DependsOn) {
                         Invoke-Task $childTask
                     }
+                    $stopwatch.Start()
 
                     $currentContext.currentTaskName = $taskName
 


### PR DESCRIPTION
This is the pull request to go along with #258

## Description
The task durations in the Build Time Report are cumulative instead of specific to each task.

For the following psake script:
```
properties {  
}

task default -depends Three

task Three -depends One, Two {
  write-host "Sleeping 1"
  Sleep 1
}

task Two -depends One {
  write-host "Sleeping 2"
  Sleep 2
}

task One {
  write-host "Sleeping 1"
  Sleep 1
}
```

I would expect the output to be:
```
----------------------------------------------------------------------
Build Time Report
----------------------------------------------------------------------
Name   Duration
----   --------
One    00:00:01.003
Two    00:00:02.003
Three  00:00:01.003
Total: 00:00:04.020
```

But the output is:
```
----------------------------------------------------------------------
Build Time Report
----------------------------------------------------------------------
Name   Duration
----   --------
One    00:00:01.003
Two    00:00:02.002
Three  00:00:04.009
Total: 00:00:04.017
```

## Related Issue
#258

## How Has This Been Tested?
I tested this locally and all current pester tests still pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
