### PR TITLE
Use $global:lastexitcode instead of $lastexitcode in Exec

### DIFF
--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -75,7 +75,7 @@ function Exec {
         try {
             $global:lastexitcode = 0
             & $cmd
-            if ($lastexitcode -ne 0) {
+            if ($global:lastexitcode -ne 0) {
                 throw "Exec: $errorMessage"
             }
             break


### PR DESCRIPTION
## Description
Use $global:lastexitcode as described in https://github.com/psake/psake/issues/203.

## Related Issue
https://github.com/psake/psake/issues/203

## Motivation and Context
Check https://github.com/psake/psake/issues/203