### PR TITLE
Add wrapper script for Linux and macOS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * -crlf
+src/psake text

--- a/src/psake
+++ b/src/psake
@@ -1,2 +1,12 @@
 #!/usr/bin/env sh
+
+# Use greadlink on macOS.
+if [ "$(uname)" = "Darwin" ]; then
+  which greadlink > /dev/null || {
+    printf 'GNU readlink not found\n'
+    exit 1
+  }
+  alias readlink="greadlink"
+fi
+
 pwsh -NoProfile -Command "& $(dirname "$(readlink -f -- "$0")")/psake.ps1 $@"

--- a/src/psake
+++ b/src/psake
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+pwsh -NoProfile -Command "& $(dirname "$(readlink -f "$0")")/psake.ps1 $@"

--- a/src/psake
+++ b/src/psake
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-pwsh -NoProfile -Command "& $(dirname "$(readlink -f "$0")")/psake.ps1 $@"
+pwsh -NoProfile -Command "& $(dirname "$(readlink -f -- "$0")")/psake.ps1 $@"

--- a/src/psake.cmd
+++ b/src/psake.cmd
@@ -1,13 +1,13 @@
 @echo off
 rem Helper script for those who want to run psake from cmd.exe
 rem Example run from cmd.exe:
-rem psake "psakefile.ps1" "BuildHelloWord" "4.0" 
+rem psake "psakefile.ps1" "BuildHelloWord" "4.0"
 
 if '%1'=='/?' goto help
 if '%1'=='-help' goto help
 if '%1'=='-h' goto help
 
-powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*; if ($psake.build_success -eq $false) { exit 1 } else { exit 0 }"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%~dp0\psake.ps1' %*"
 exit /B %errorlevel%
 
 :help

--- a/src/psake.ps1
+++ b/src/psake.ps1
@@ -65,3 +65,7 @@ if ($buildFile -and (-not (Test-Path -Path $buildFile))) {
 }
 
 Invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo $detailedDocs $notr
+
+if (!$psake.build_success) {
+    exit 1
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

There is `psake.cmd` wrapper script to run psake tasks on Windows. I added a similar wrapper for Linux and macOS.

- Set correct exit code in psake.ps1.
- Introduce psake wrapper script.
- Make src/psake executable, set correct autocrlf settings.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#262

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It allows to use `psake` command to run psake tasks on Linux and macOS. Also psake.ps1 returns correct exit code now.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created tasks that may produce errors:

```powershell
Task test `
{
    Hi-There
}
```


```sh
echo 'Task test { Hi-There }' > Test1.ps1
```

```powershell
Task test `
    -requiredVariables @('SomeValue') `
{
    "Test $SomeValue"
}
```

```sh
echo "Task test -requiredVariables @('SomeValue') { \"Test \$SomeValue\" }" > Test2.ps1
```

```powershell
Task test `
{
    $PSVersionTable
}
```

```sh
echo 'Task test { $PSVersionTable }' > Test3.ps1
```

Tested them on Ubuntu 18.04 (PowerShell Core 6.1).

```sh
git clone https://github.com/Saritasa/psake psake-fix-test
cd psake-fix-test/
git checkout fix/add-support-of-linux-and-macos-2
sudo ln -s `pwd`/src/psake /usr/bin/psake
```

```sh
psake Test1.ps1 test ; echo $?
psake Test2.ps1 test ; echo $?
psake Test2.ps1 test -parameters '@{SomeValue=123}' ; echo $?
psake Test3.ps1 test ; echo $?
```

Made sure correct exit code is returned.

Also I tested `psake.cmd` wrapper on Windows 10 (PowerShell 5.1).

```powershell
&"psake-fix-test\src\psake.cmd" Test1.ps1 test ; echo $LASTEXITCODE
&"psake-fix-test\src\psake.cmd" Test2.ps1 test ; echo $LASTEXITCODE
&"psake-fix-test\src\psake.cmd" Test2.ps1 test -parameters '@{SomeValue=123}' ; echo $LASTEXITCODE
&"psake-fix-test\src\psake.cmd" Test3.ps1 test ; echo $LASTEXITCODE
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
