### PR TITLE
GH Issue #268 Version Check Too Strict

### DIFF
--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -204,7 +204,11 @@ function Task {
         if ($taskModule = Get-Module -Name $FromModule) {
             # Use the task module that is already loaded into the session
             if ($Version) {
-                $taskModule = $taskModule | Where-Object {$_.Version -eq $Version}
+                $comparison = {
+                    ($_.Version.Major -eq $Version.Major) -and
+                    ($_.Version.Minor -ge $Version.Minor)
+                }
+                $taskModule = $taskModule | Where-Object -FilterScript $comparison
             } else {
                 $taskModule = $taskModule | Sort-Object -Property Version -Descending | Select-Object -First 1
             }


### PR DESCRIPTION
When checking the version of the from module in task.ps1, the version
check is very strict. A difference in the z release of the installed
module will cause the module to be rejected and the task to fail.

## Related Issue
#268 

## Motivation and Context
It allows users to keep up with projects that do rapid y and z releases without having to constantly running into build failures if a project releases patches or feature releases, and without having to pin to really specific releases to avoid those failures.

## How Has This Been Tested?
Tested locally by duplicating the issue and then verifying that tasks will now run with a mismatched z release.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
