### PR TITLE
Extend parameters initialization error handling. If parameters initialization failed, show which parameter caused a failure.

### DIFF
--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -263,12 +263,17 @@ function Invoke-psake {
                 return
             }
 
-            foreach ($key in $parameters.keys) {
-                if (test-path "variable:\$key") {
-                    set-item -path "variable:\$key" -value $parameters.$key -WhatIf:$false -Confirm:$false | out-null
-                } else {
-                    new-item -path "variable:\$key" -value $parameters.$key -WhatIf:$false -Confirm:$false | out-null
+            try {
+                foreach ($key in $parameters.keys) {
+                    if (test-path "variable:\$key") {
+                        set-item -path "variable:\$key" -value $parameters.$key -WhatIf:$false -Confirm:$false | out-null
+                    } else {
+                        new-item -path "variable:\$key" -value $parameters.$key -WhatIf:$false -Confirm:$false | out-null
+                    }
                 }
+            } catch {
+                WriteColoredOutput "Parameter '$key' is null" -foregroundcolor Red
+                throw
             }
 
             # The initial dot (.) indicates that variables initialized/modified in the propertyBlock are available in the parent scope.


### PR DESCRIPTION
## Description
Add `try/catch` block around parameters initialization loop. In `catch` show `$parameters.$keys`, and then throw an error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/psake/psake/issues/271

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
You can have a bunch of parameters, which must be initialized by a build server and passed to Invoke-psake. If one of them is not passed, you get:
` +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ [<<==>>] Exception: Cannot process argument because the value of argument "value" is null. Change the value of argument "value" to a non
-null value.`

And it's really not clear which parameter is null.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
