### PR TITLE
Pass task detail including error into TaskSetup and TaskTearDown

### DIFF
--- a/specs/taskTearDown_runs_on_failed_test_has_access_to_error_and_should_fail.ps1
+++ b/specs/taskTearDown_runs_on_failed_test_has_access_to_error_and_should_fail.ps1
@@ -1,0 +1,29 @@
+task default -depends Test
+
+task Test -depends Compile, Clean {
+    Assert $false "This fails."
+}
+
+task Compile -depends Clean {
+    "Compile"
+}
+
+task Clean {
+    "Clean"
+}
+
+taskTearDown {
+    param($task)
+
+    Assert ($task.Name -eq $psake.context.Peek().currentTaskName) 'TaskName should match'
+    if ($task.Success) {
+        "'$($task.Name)' Tear Down: task passed!"
+    } else {
+        "'$($task.Name)' Tear Down: task failed with '$($task.ErrorMessage)'"
+        "-------------------"
+        "- ErrorMessage: '$($task.ErrorMessage)'"
+        "- ErrorDetail: $($task.ErrorDetail)"
+        "- ErrorFormatted: $($task.ErrorFormatted)"
+        "-------------------"
+    }
+}

--- a/specs/taskTearDown_runs_on_success_should_pass.ps1
+++ b/specs/taskTearDown_runs_on_success_should_pass.ps1
@@ -1,0 +1,19 @@
+task default -depends Test
+
+task Test -depends Compile, Clean {}
+
+task Compile -depends Clean {
+    "Compile"
+}
+
+task Clean {
+    "Clean"
+}
+
+taskTearDown {
+    param($task)
+
+    Assert ($task -ne $null) '$task should not be null'
+    Assert (-not ([string]::IsNullOrWhiteSpace($task.Name))) '$task.Name should not be null'
+    "'$($task.Name)' Tear Down"
+}

--- a/specs/tasksetup_with_task_argument_should_pass.ps1
+++ b/specs/tasksetup_with_task_argument_should_pass.ps1
@@ -1,0 +1,21 @@
+TaskSetup {
+    param($task)
+
+    "Setting up: '$($task.Name)'"
+    Assert ($task -ne $null) '$task should not be null'
+    Assert (-not ([string]::IsNullOrWhiteSpace($task.Name))) '$task.Name should not be empty'
+}
+
+Task default -depends Compile, Test, Deploy
+
+Task Compile {
+    "Compiling"
+}
+
+Task Test -depends Compile {
+    "Testing"
+}
+
+Task Deploy -depends Test {
+    "Deploying"
+}

--- a/src/private/FormatErrorMessage.ps1
+++ b/src/private/FormatErrorMessage.ps1
@@ -1,0 +1,26 @@
+function FormatErrorMessage
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipeline=$true)]
+        $ErrorRecord = $Error[0]
+    )
+
+    $currentConfig = GetCurrentConfigurationOrDefault
+    if ($currentConfig.verboseError) {
+        $error_message = "{0}: An Error Occurred. See Error Details Below: $($script:nl)" -f (Get-Date)
+        $error_message += ("-" * 70) + $script:nl
+        $error_message += "Error: {0}$($script:nl)" -f (ResolveError $_ -Short)
+        $error_message += ("-" * 70) + $script:nl
+        $error_message += ResolveError $_
+        $error_message += ("-" * 70) + $script:nl
+        $error_message += "Script Variables" + $script:nl
+        $error_message += ("-" * 70) + $script:nl
+        $error_message += get-variable -scope script | format-table | out-string
+    } else {
+        # ($_ | Out-String) gets error messages with source information included.
+        $error_message = "Error: {0}: $($script:nl){1}" -f (Get-Date), (ResolveError $_ -Short)
+}
+
+    $error_message
+}

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -88,7 +88,7 @@ function Invoke-Task {
                     $currentContext.currentTaskName = $taskName
 
                     try {
-                        & $currentContext.taskSetupScriptBlock
+                        & $currentContext.taskSetupScriptBlock @($task)
                         try {
                             if ($task.PreAction) {
                                 & $task.PreAction
@@ -111,8 +111,35 @@ function Invoke-Task {
                                 & $task.PostAction
                             }
                         }
+                    } catch {
+                        # want to catch errors here _before_ we invoke TaskTearDown
+                        # so that TaskTearDown reliably gets the Task-scoped
+                        # success/fail/error context.
+
+                        $currentConfig = GetCurrentConfigurationOrDefault
+                        if ($currentConfig.verboseError) {
+                            $error_message = "{0}: An Error Occurred. See Error Details Below: $($script:nl)" -f (Get-Date)
+                            $error_message += ("-" * 70) + $script:nl
+                            $error_message += "Error: {0}$($script:nl)" -f (ResolveError $_ -Short)
+                            $error_message += ("-" * 70) + $script:nl
+                            $error_message += ResolveError $_
+                            $error_message += ("-" * 70) + $script:nl
+                            $error_message += "Script Variables" + $script:nl
+                            $error_message += ("-" * 70) + $script:nl
+                            $error_message += get-variable -scope script | format-table | out-string
+                        } else {
+                            # ($_ | Out-String) gets error messages with source information included.
+                            $error_message = "Error: {0}: $($script:nl){1}" -f (Get-Date), (ResolveError $_ -Short)
+                        }
+
+                        $task.Success        = $false
+                        $task.ErrorMessage   = $_
+                        $task.ErrorDetail    = $_ | Out-String
+                        $task.ErrorFormatted = $error_message
+
+                        throw $_ # pass this up the chain; don't have to cleanup here
                     } finally {
-                        & $currentContext.taskTearDownScriptBlock
+                        & $currentContext.taskTearDownScriptBlock $task
                     }
                 } catch {
                     if ($task.ContinueOnError) {

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -115,29 +115,12 @@ function Invoke-Task {
                         # want to catch errors here _before_ we invoke TaskTearDown
                         # so that TaskTearDown reliably gets the Task-scoped
                         # success/fail/error context.
-
-                        $currentConfig = GetCurrentConfigurationOrDefault
-                        if ($currentConfig.verboseError) {
-                            $error_message = "{0}: An Error Occurred. See Error Details Below: $($script:nl)" -f (Get-Date)
-                            $error_message += ("-" * 70) + $script:nl
-                            $error_message += "Error: {0}$($script:nl)" -f (ResolveError $_ -Short)
-                            $error_message += ("-" * 70) + $script:nl
-                            $error_message += ResolveError $_
-                            $error_message += ("-" * 70) + $script:nl
-                            $error_message += "Script Variables" + $script:nl
-                            $error_message += ("-" * 70) + $script:nl
-                            $error_message += get-variable -scope script | format-table | out-string
-                        } else {
-                            # ($_ | Out-String) gets error messages with source information included.
-                            $error_message = "Error: {0}: $($script:nl){1}" -f (Get-Date), (ResolveError $_ -Short)
-                        }
-
                         $task.Success        = $false
                         $task.ErrorMessage   = $_
                         $task.ErrorDetail    = $_ | Out-String
-                        $task.ErrorFormatted = $error_message
+                        $task.ErrorFormatted = FormatErrorMessage $_
 
-                        throw $_ # pass this up the chain; don't have to cleanup here
+                        throw $_ # pass this up the chain; cleanup is handled higher int he stack
                     } finally {
                         & $currentContext.taskTearDownScriptBlock $task
                     }

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -317,24 +317,8 @@ function Invoke-psake {
         $psake.build_success = $true
 
     } catch {
-        $currentConfig = GetCurrentConfigurationOrDefault
-        if ($currentConfig.verboseError) {
-            $error_message = "{0}: An Error Occurred. See Error Details Below: $($script:nl)" -f (Get-Date)
-            $error_message += ("-" * 70) + $script:nl
-            $error_message += "Error: {0}$($script:nl)" -f (ResolveError $_ -Short)
-            $error_message += ("-" * 70) + $script:nl
-            $error_message += ResolveError $_
-            $error_message += ("-" * 70) + $script:nl
-            $error_message += "Script Variables" + $script:nl
-            $error_message += ("-" * 70) + $script:nl
-            $error_message += get-variable -scope script | format-table | out-string
-        } else {
-            # ($_ | Out-String) gets error messages with source information included.
-            $error_message = "Error: {0}: $($script:nl){1}" -f (Get-Date), (ResolveError $_ -Short)
-        }
-
         $psake.build_success = $false
-        $psake.error_message = $error_message
+        $psake.error_message = FormatErrorMessage $_
 
         # if we are running in a nested scope (i.e. running a psake script from a psake script) then we need to re-throw the exception
         # so that the parent script will fail otherwise the parent script will report a successful build

--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -203,6 +203,10 @@ function Task {
             Duration          = [System.TimeSpan]::Zero
             RequiredVariables = $requiredVariables
             Alias             = $alias
+            Success = $true # let's be optimistic
+            ErrorMessage = $nill
+            ErrorDetail = $nill
+            ErrorFormatted = $nill
         }
     }
 

--- a/src/public/TaskSetup.ps1
+++ b/src/public/TaskSetup.ps1
@@ -6,6 +6,8 @@ function TaskSetup {
         .DESCRIPTION
         This function will accept a scriptblock that will be executed before each task in the build script.
 
+        The scriptblock accepts an optional parameter which describes the Task being setup.
+
         .PARAMETER setup
         A scriptblock to execute
 
@@ -25,6 +27,37 @@ function TaskSetup {
 
         TaskSetup {
             "Running 'TaskSetup' for task $context.Peek().currentTaskName"
+        }
+
+        The script above produces the following output:
+
+        Running 'TaskSetup' for task Clean
+        Executing task, Clean...
+        Running 'TaskSetup' for task Compile
+        Executing task, Compile...
+        Running 'TaskSetup' for task Test
+        Executing task, Test...
+
+        Build Succeeded
+
+        .EXAMPLE
+        A sample build script showing access to the Task context is shown below:
+
+        Task default -depends Test
+
+        Task Test -depends Compile, Clean {
+        }
+
+        Task Compile -depends Clean {
+        }
+
+        Task Clean {
+        }
+
+        TaskSetup {
+            param($task)
+
+            "Running 'TaskSetup' for task $($task.Name)"
         }
 
         The script above produces the following output:

--- a/src/public/TaskTearDown.ps1
+++ b/src/public/TaskTearDown.ps1
@@ -7,6 +7,8 @@ function TaskTearDown {
         .DESCRIPTION
         This function will accept a scriptblock that will be executed after each task in the build script.
 
+        The scriptblock accepts an optional parameter which describes the Task being torn down.
+
         .PARAMETER teardown
         A scriptblock to execute
 
@@ -36,6 +38,41 @@ function TaskTearDown {
         Running 'TaskTearDown' for task Compile
         Executing task, Test...
         Running 'TaskTearDown' for task Test
+
+        Build Succeeded
+
+        .EXAMPLE
+        A sample build script demonstrating access to the task context is shown below:
+
+        Task default -depends Test
+
+        Task Test -depends Compile, Clean {
+        }
+
+        Task Compile -depends Clean {
+        }
+
+        Task Clean {
+        }
+
+        TaskTearDown {
+            param($task)
+
+            if ($task.Success) {
+                "Running 'TaskTearDown' for task $($task.Name) - success!"
+            } else {
+                "Running 'TaskTearDown' for task $($task.Name) - failed: $($task.ErrorMessage)"
+            }
+        }
+
+        The script above produces the following output:
+
+        Executing task, Clean...
+        Running 'TaskTearDown' for task Clean - success!
+        Executing task, Compile...
+        Running 'TaskTearDown' for task Compile - success!
+        Executing task, Test...
+        Running 'TaskTearDown' for task Test - success!
 
         Build Succeeded
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I have copied the exception handling from `Invoke-Psake` into the try/catch block of `Invoke-Task` so that we can trap errors and capture error detail before invoking the `finally` clause which calls `TaskTearDown`; this allows `TaskTearDown` to operate in the context of the current task's status including any error detail on failure.

This PR also proposes passing the `$task` parameter in the heart of `Invoke-Task` into `TaskSetup` and `TaskTearDown` as optional parameters so that instead of doing this:
```
taskSetup {
    "Begin task: '$($psake.context.Peek().currentTaskName)'"
}
```
we can do this:
```
taskSetup {
    "Begin task: '$($psake.context.Peek().currentTaskName)'"
}
```

Using the same technique in `TaskTearDown` and setting some additional properties on the `Task` instance we can now do this:
```
taskTearDown {
    param($task)

    if ($task.Success) {
        "'$($task.Name)' Tear Down: task passed!"
    } else {
        "'$($task.Name)' Tear Down: task failed with '$($task.ErrorMessage)'"
    }
}
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[#275 TaskTearDown doesn't have access to task_succeeded or task_error_message context](https://github.com/psake/psake/issues/275)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As explained in #275 I was looking for a way to refactor common plumbing out of my individual psake tasks and express them in common Setup and TearDown code, but wanted access to whether the current task passed or failed and if it failed, access to the error message.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
In the following environment, `invoke-pester` on the root folder shows that all existing specs pass and a few new ones demonstrate the additional opt-in syntax and behaviour.

### My Environment
<!--- Include as many relevant details about the environment you experienced the bug in -->
* Module version used: `psake 4.7.4`
* Operating System: 
![image](https://user-images.githubusercontent.com/43332/54652153-d36fc700-4a83-11e9-9b50-398adcc1a788.png)

* PowerShell version: 
```
PS C:\dev\psake-test> get-host

Name             : ConsoleHost
Version          : 5.1.17763.316
InstanceId       : cf5e4b3b-1d00-42e4-9bc7-3a84c02aa881
UI               : System.Management.Automation.Internal.Host.InternalHostUserInterface
CurrentCulture   : en-US
CurrentUICulture : en-US
PrivateData      : Microsoft.PowerShell.ConsoleHost+ConsoleColorProxy
DebuggerEnabled  : True
IsRunspacePushed : False
Runspace         : System.Management.Automation.Runspaces.LocalRunspace
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
