### PR TITLE
Add support .net 4.8

### DIFF
--- a/specs/dotNet4.8_should_pass.ps1
+++ b/specs/dotNet4.8_should_pass.ps1
@@ -1,0 +1,9 @@
+Framework '4.8'
+    task default -depends MsBuild
+    task MsBuild {
+    if ( $IsMacOS -OR $IsLinux ) {}
+    else {
+        $output = &msbuild /version /nologo 2>&1
+        Assert ($output -NotLike '15.0') '$output should contain 15.0'
+    }
+}

--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -48,6 +48,10 @@ function ConfigureBuildEnvironment {
                 $versions = @('v4.0.30319')
                 $buildToolsVersions = @('16.0', '15.0')
             }
+            '4.8' {
+                $versions = @('v4.0.30319')
+                $buildToolsVersions = @('15.0')
+            }
 
             default {
                 throw ($msgs.error_unknown_framework -f $versionPart, $framework)


### PR DESCRIPTION
## Description
Added .net 4.8 to ConfigureBuildEnvironment.ps1, with only build tools 15.0

## Related Issue
#280 

## Motivation and Context

## How Has This Been Tested?
ci/cd tests are passing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
