### PR TITLE
Fix for path issue for VS 2019 described in comments of #278

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [4.8.1] Unreleased
+## [4.8.2] Unreleased
 
 ### Fixed
 

--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -50,7 +50,7 @@ function ConfigureBuildEnvironment {
             }
             '4.8' {
                 $versions = @('v4.0.30319')
-                $buildToolsVersions = @('15.0')
+                $buildToolsVersions = @('16.0', '15.0')
             }
 
             default {
@@ -106,7 +106,7 @@ function ConfigureBuildEnvironment {
 
                     # borrowed from nightroman https://github.com/nightroman/Invoke-Build
                     if ($vsInstances = Get-VSSetupInstance) {
-                        $vs = @($vsInstances | Select-VSSetupInstance -Version '[15.0,)' -Require Microsoft.Component.MSBuild)
+                        $vs = @($vsInstances | Select-VSSetupInstance -Version '[15.0, 16.0)' -Require Microsoft.Component.MSBuild)
                         if ($vs) {
                             if ($buildToolsKey -eq 'MSBuildToolsPath32') {
                                 $frameworkDirs += Join-Path ($vs[0].InstallationPath) MSBuild\15.0\Bin
@@ -116,7 +116,7 @@ function ConfigureBuildEnvironment {
                             }
                         }
 
-                        $vs = @($vsInstances | Select-VSSetupInstance -Version '[15.0,)' -Product Microsoft.VisualStudio.Product.BuildTools)
+                        $vs = @($vsInstances | Select-VSSetupInstance -Version '[15.0, 16.0)' -Product Microsoft.VisualStudio.Product.BuildTools)
                         if ($vs) {
                             if ($buildToolsKey -eq 'MSBuildToolsPath32') {
                                 $frameworkDirs += Join-Path ($vs[0].InstallationPath) MSBuild\15.0\Bin

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'psake.psm1'
-    ModuleVersion     = '4.8.1'
+    ModuleVersion     = '4.8.2'
     GUID              = 'cfb53216-072f-4a46-8975-ff7e6bda05a5'
     Author            = 'James Kovacs'
     Copyright         = 'Copyright (c) 2010-18 James Kovacs, Damian Hickey, Brandon Olin, and Contributors'


### PR DESCRIPTION
Fix issues described in #278, where the path for 15.0 tools is determined when only 16.0 tools are installed.

## Description
The logic in ConfigureBuildEnvironment which determines $frameworkDirs was incorrectly including 16.0 (e.g. VS 2019) in it's version lookup. If 16.0+ of VSSetupInstance existed, the $frameworkDir would incorrectly be set to MSBuild\15.0\Bin\amd64.

Change the logic to constrain version search to [15.0, 16.0) for $buildToolsVersions containing "15.0", and allowing [16.0, ] to be considered for "16.0"

Also, include MSBuild 16.0 in the 4.8 environment configuration path.

## Related Issue
#278 

## Motivation and Context
Allows building when only VS 2019 (or tools) are installed.

## How Has This Been Tested?
Executed .\build.ps1 Build && .\build.ps1 Test
![image](https://user-images.githubusercontent.com/1771738/59790490-a9ea5580-9295-11e9-9e8c-365fb5e87379.png)

Locally on two machines - 
  1 containing VS 2019 Professional only, 
  1 containing VS 2017 build tools (https://visualstudio.microsoft.com/thank-you-downloading-visual-studio/?sku=BuildTools&rel=15&src=myvs) and VS 2019 Professional

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1771738/59790565-d43c1300-9295-11e9-8167-2028151649a7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
