### PR TITLE
BuildSetup and BuildTearDown Feature

### DIFF
--- a/docs/reference/functions/BuildSetup.md
+++ b/docs/reference/functions/BuildSetup.md
@@ -1,0 +1,93 @@
+---
+external help file: psake-help.xml
+Module Name: psake
+online version:
+schema: 2.0.0
+---
+
+# BuildSetup
+
+## SYNOPSIS
+Adds a scriptblock that will be executed once at the beginning of the build
+
+## SYNTAX
+
+```
+BuildSetup [-setup] <ScriptBlock> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This function will accept a scriptblock that will be executed once at the beginning of the build.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+A sample build script is shown below:
+```
+
+Task default -depends Test
+Task Test -depends Compile, Clean {
+}
+Task Compile -depends Clean {
+}
+Task Clean {
+}
+BuildSetup {
+    "Running 'BuildSetup'"
+}
+The script above produces the following output:
+Running 'BuildSetup'
+Executing task, Clean...
+Executing task, Compile...
+Executing task, Test...
+Build Succeeded
+
+## PARAMETERS
+
+### -setup
+A scriptblock to execute
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Assert]()
+
+[Exec]()
+
+[FormatTaskName]()
+
+[Framework]()
+
+[Invoke-psake]()
+
+[Properties]()
+
+[Task]()
+
+[BuildTearDown]()
+
+[TaskSetup]()
+
+[TaskTearDown]()
+

--- a/docs/reference/functions/BuildTearDown.md
+++ b/docs/reference/functions/BuildTearDown.md
@@ -1,0 +1,117 @@
+---
+external help file: psake-help.xml
+Module Name: psake
+online version:
+schema: 2.0.0
+---
+
+# BuildTearDown
+
+## SYNOPSIS
+Adds a scriptblock that will be executed once at the end of the build
+
+## SYNTAX
+
+```
+BuildTearDown [-setup] <ScriptBlock> [<CommonParameters>]
+```
+
+## DESCRIPTION
+This function will accept a scriptblock that will be executed once at the end of the build, regardless of success or failure
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+A sample build script is shown below:
+```
+
+Task default -depends Test
+Task Test -depends Compile, Clean {
+}
+Task Compile -depends Clean {
+}
+Task Clean {
+}
+BuildTearDown {
+    "Running 'BuildTearDown'"
+}
+The script above produces the following output:
+Executing task, Clean...
+Executing task, Compile...
+Executing task, Test...
+Running 'BuildTearDown'
+Build Succeeded
+
+### EXAMPLE 2
+```
+A failing build script is shown below:
+```
+
+Task default -depends Test
+Task Test -depends Compile, Clean {
+    throw "forced error"
+}
+Task Compile -depends Clean {
+}
+Task Clean {
+}
+BuildTearDown {
+    "Running 'BuildTearDown'"
+}
+The script above produces the following output:
+Executing task, Clean...
+Executing task, Compile...
+Executing task, Test...
+Running 'BuildTearDown'
+forced error
+At line:x char:x ...
+
+## PARAMETERS
+
+### -setup
+A scriptblock to execute
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[Assert]()
+
+[Exec]()
+
+[FormatTaskName]()
+
+[Framework]()
+
+[Invoke-psake]()
+
+[Properties]()
+
+[Task]()
+
+[BuildSetup]()
+
+[TaskSetup]()
+
+[TaskTearDown]()
+

--- a/docs/structure-of-a-psake-build-script.md
+++ b/docs/structure-of-a-psake-build-script.md
@@ -12,6 +12,7 @@ The functions are the following:
 |_FormatTaskName()_|Allows you to reformat how psake displays the currently running task|no|
 |_TaskSetup()_|A function that will run before each task is executed|no|
 |_TaskTearDown()_|A function that will run after each task|no|
+|_BuildSetup()_|A script block that will run before the first task|no|
 
 An example psake script:
 <hr/>
@@ -38,12 +39,14 @@ Task Clean {
 <BuildScript> ::= <Includes> 
                 | <Properties>
                 | <FormatTaskName> 
+                | <BuildSetup> 
                 | <TaskSetup> 
                 | <TaskTearDown> 
                 | <Tasks> 
 <Includes> ::= Include <StringLiteral> | <Includes>
 <Properties> ::= Properties <ScriptBlock> | <Properties>
 <FormatTaskName> ::= FormatTaskName <Stringliteral>
+<BuildSetup> ::= BuildSetup <ScriptBlock>
 <TaskSetup> ::= TaskSetup <ScriptBlock>
 <TaskTearDown> ::= TaskTearDown <ScriptBlock>
 <Tasks> ::= Task <TaskParameters> | <Tasks>

--- a/docs/structure-of-a-psake-build-script.md
+++ b/docs/structure-of-a-psake-build-script.md
@@ -12,7 +12,8 @@ The functions are the following:
 |_FormatTaskName()_|Allows you to reformat how psake displays the currently running task|no|
 |_TaskSetup()_|A function that will run before each task is executed|no|
 |_TaskTearDown()_|A function that will run after each task|no|
-|_BuildSetup()_|A script block that will run before the first task|no|
+|_BuildSetup()_|A script block that will run before the first task starts|no|
+|_BuildTearDown()_|A script block that will run when either all tasks have completed, or the build has failed|no|
 
 An example psake script:
 <hr/>
@@ -47,6 +48,7 @@ Task Clean {
 <Properties> ::= Properties <ScriptBlock> | <Properties>
 <FormatTaskName> ::= FormatTaskName <Stringliteral>
 <BuildSetup> ::= BuildSetup <ScriptBlock>
+<BuildTearDown> ::= BuildTearDown <ScriptBlock>
 <TaskSetup> ::= TaskSetup <ScriptBlock>
 <TaskTearDown> ::= TaskTearDown <ScriptBlock>
 <Tasks> ::= Task <TaskParameters> | <Tasks>

--- a/specs/buildsetup_can_access_properties_should_pass.ps1
+++ b/specs/buildsetup_can_access_properties_should_pass.ps1
@@ -1,0 +1,24 @@
+Properties {
+    [string]$testProperty = "Test123"
+}
+
+BuildSetup {
+    [string]$expected = "Test123"
+    if ($testProperty -ne $expected) {
+        throw "Expected sequence '$expected', but was actually '$script:sequence'"
+    }
+}
+
+Task default -depends Compile, Test, Deploy
+
+Task Compile {
+    "Compiling;"
+}
+
+Task Test -depends Compile {
+    "Testing;"
+}
+
+Task Deploy -depends Test {
+    "Deploying"
+}

--- a/specs/buildsetup_can_access_properties_should_pass.ps1
+++ b/specs/buildsetup_can_access_properties_should_pass.ps1
@@ -5,18 +5,18 @@ Properties {
 BuildSetup {
     [string]$expected = "Test123"
     if ($testProperty -ne $expected) {
-        throw "Expected sequence '$expected', but was actually '$script:sequence'"
+        throw "Expected sequence '$expected', but was actually '$testProperty'"
     }
 }
 
 Task default -depends Compile, Test, Deploy
 
 Task Compile {
-    "Compiling;"
+    "Compiling"
 }
 
 Task Test -depends Compile {
-    "Testing;"
+    "Testing"
 }
 
 Task Deploy -depends Test {

--- a/specs/buildsetup_failure_should_fail.ps1
+++ b/specs/buildsetup_failure_should_fail.ps1
@@ -5,11 +5,11 @@ BuildSetup {
 Task default -depends Compile, Test, Deploy
 
 Task Compile {
-    "Compiling;"
+    "Compiling"
 }
 
 Task Test -depends Compile {
-    "Testing;"
+    "Testing"
 }
 
 Task Deploy -depends Test {

--- a/specs/buildsetup_failure_should_fail.ps1
+++ b/specs/buildsetup_failure_should_fail.ps1
@@ -1,0 +1,17 @@
+BuildSetup {
+    throw "forced error"
+}
+
+Task default -depends Compile, Test, Deploy
+
+Task Compile {
+    "Compiling;"
+}
+
+Task Test -depends Compile {
+    "Testing;"
+}
+
+Task Deploy -depends Test {
+    "Deploying"
+}

--- a/specs/buildsetup_runs_once_should_pass.ps1
+++ b/specs/buildsetup_runs_once_should_pass.ps1
@@ -1,0 +1,24 @@
+BuildSetup {
+    $script:sequence += "executing build setup;"
+}
+
+Task default -depends Test-Results
+
+Task Test-Results -depends Compile, Test, Deploy {
+    [string]$expected = "executing build setup;Compiling;Testing;Deploying"
+    if ($script:sequence -ne $expected) {
+        throw "Expected sequence '$expected', but was actually '$script:sequence'"
+    }
+}
+
+Task Compile {
+    $script:sequence += "Compiling;"
+}
+
+Task Test -depends Compile {
+    $script:sequence += "Testing;"
+}
+
+Task Deploy -depends Test {
+    $script:sequence += "Deploying"
+}

--- a/specs/buildteardown_can_access_properties_should_pass.ps1
+++ b/specs/buildteardown_can_access_properties_should_pass.ps1
@@ -1,0 +1,24 @@
+Properties {
+    [string]$testProperty = "Test123"
+}
+
+BuildTearDown {
+    [string]$expected = "Test123"
+    if ($testProperty -ne $expected) {
+        throw "Expected '$expected', but was actually '$testProperty'"
+    }
+}
+
+Task default -depends Compile,Test,Deploy
+
+Task Compile {
+    "Compiling"
+}
+
+Task Test -depends Compile {
+    "Testing"
+}
+
+Task Deploy -depends Test {
+    "Deploying"
+}

--- a/specs/buildteardown_failure_should_fail.ps1
+++ b/specs/buildteardown_failure_should_fail.ps1
@@ -1,0 +1,17 @@
+BuildTearDown {
+    throw "forced error"
+}
+
+Task default -depends Compile,Test,Deploy
+
+Task Compile {
+    "Compiling;"
+}
+
+Task Test -depends Compile {
+    "Testing;"
+}
+
+Task Deploy -depends Test {
+    "Deploying;"
+}

--- a/specs/buildteardown_runs_once_should_pass.ps1
+++ b/specs/buildteardown_runs_once_should_pass.ps1
@@ -1,0 +1,25 @@
+BuildTearDown {
+    $script:buildTearDown_Sequence += "executing build teardown"
+    [string]$expected = "Compiling;Testing;Deploying;executing build teardown"
+    if ($script:buildTearDown_Sequence -ne $expected) {
+        throw "Expected sequence '$expected', but was actually '$script:buildTearDown_Sequence'"
+    }
+}
+
+Task default -depends Test-Results
+
+Task Test-Results -depends Compile, Test, Deploy {
+
+}
+
+Task Compile {
+    $script:buildTearDown_Sequence += "Compiling;"
+}
+
+Task Test -depends Compile {
+    $script:buildTearDown_Sequence += "Testing;"
+}
+
+Task Deploy -depends Test {
+    $script:buildTearDown_Sequence += "Deploying;"
+}

--- a/src/private/ExecuteInBuildFileScope.ps1
+++ b/src/private/ExecuteInBuildFileScope.ps1
@@ -12,6 +12,7 @@ function ExecuteInBuildFileScope {
     $psake.context.push(
         @{
             "buildSetupScriptBlock"         = {}
+            "buildTearDownScriptBlock"      = {}
             "taskSetupScriptBlock"          = {}
             "taskTearDownScriptBlock"       = {}
             "executedTasks"                 = new-object System.Collections.Stack

--- a/src/private/ExecuteInBuildFileScope.ps1
+++ b/src/private/ExecuteInBuildFileScope.ps1
@@ -11,6 +11,7 @@ function ExecuteInBuildFileScope {
     # Create a new psake context
     $psake.context.push(
         @{
+            "buildSetupScriptBlock"         = {}
             "taskSetupScriptBlock"          = {}
             "taskTearDownScriptBlock"       = {}
             "executedTasks"                 = new-object System.Collections.Stack

--- a/src/public/BuildSetup.ps1
+++ b/src/public/BuildSetup.ps1
@@ -4,7 +4,6 @@ function BuildSetup {
         Adds a scriptblock that will be executed once at the beginning of the build
         .DESCRIPTION
         This function will accept a scriptblock that will be executed once at the beginning of the build.
-        The scriptblock accepts an optional parameter which describes the Task being setup.
         .PARAMETER setup
         A scriptblock to execute
         .EXAMPLE
@@ -39,10 +38,12 @@ function BuildSetup {
         Properties
         .LINK
         Task
-       .LINK
-        TaskSetup
         .LINK
-        TaskTearDown
+        BuildTearDown
+        .LINK
+         TaskSetup
+         .LINK
+         TaskTearDown
     #>
     [CmdletBinding()]
     param(

--- a/src/public/BuildSetup.ps1
+++ b/src/public/BuildSetup.ps1
@@ -1,0 +1,54 @@
+function BuildSetup {
+    <#
+        .SYNOPSIS
+        Adds a scriptblock that will be executed once at the beginning of the build
+        .DESCRIPTION
+        This function will accept a scriptblock that will be executed once at the beginning of the build.
+        The scriptblock accepts an optional parameter which describes the Task being setup.
+        .PARAMETER setup
+        A scriptblock to execute
+        .EXAMPLE
+        A sample build script is shown below:
+        Task default -depends Test
+        Task Test -depends Compile, Clean {
+        }
+        Task Compile -depends Clean {
+        }
+        Task Clean {
+        }
+        BuildSetup {
+            "Running 'BuildSetup'"
+        }
+        The script above produces the following output:
+        Running 'BuildSetup'
+        Executing task, Clean...
+        Executing task, Compile...
+        Executing task, Test...
+        Build Succeeded
+        .LINK
+        Assert
+        .LINK
+        Exec
+        .LINK
+        FormatTaskName
+        .LINK
+        Framework
+        .LINK
+        Invoke-psake
+        .LINK
+        Properties
+        .LINK
+        Task
+       .LINK
+        TaskSetup
+        .LINK
+        TaskTearDown
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$setup
+    )
+
+    $psake.context.Peek().buildSetupScriptBlock = $setup
+}

--- a/src/public/BuildTearDown.ps1
+++ b/src/public/BuildTearDown.ps1
@@ -1,0 +1,77 @@
+function BuildTearDown {
+    <#
+        .SYNOPSIS
+        Adds a scriptblock that will be executed once at the end of the build
+        .DESCRIPTION
+        This function will accept a scriptblock that will be executed once at the end of the build, regardless of success or failure
+        The scriptblock accepts an optional parameter which describes the Task being setup.
+        .PARAMETER setup
+        A scriptblock to execute
+        .EXAMPLE
+        A sample build script is shown below:
+        Task default -depends Test
+        Task Test -depends Compile, Clean {
+        }
+        Task Compile -depends Clean {
+        }
+        Task Clean {
+        }
+        BuildTearDown {
+            "Running 'BuildTearDown'"
+        }
+        The script above produces the following output:
+        Executing task, Clean...
+        Executing task, Compile...
+        Executing task, Test...
+        Running 'BuildTearDown'
+        Build Succeeded
+        .EXAMPLE
+        A failing build script is shown below:
+        Task default -depends Test
+        Task Test -depends Compile, Clean {
+            throw "forced error"
+        }
+        Task Compile -depends Clean {
+        }
+        Task Clean {
+        }
+        BuildTearDown {
+            "Running 'BuildTearDown'"
+        }
+        The script above produces the following output:
+        Executing task, Clean...
+        Executing task, Compile...
+        Executing task, Test...
+        Task failed : forced error
+        Running 'BuildTearDown'
+        forced error
+        At line:x char:x
+        .LINK
+        Assert
+        .LINK
+        Exec
+        .LINK
+        FormatTaskName
+        .LINK
+        Framework
+        .LINK
+        Invoke-psake
+        .LINK
+        Properties
+        .LINK
+        Task
+        .LINK
+        BuildSetup
+        .LINK
+        TaskSetup
+        .LINK
+        TaskTearDown
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$setup
+    )
+
+    $psake.context.Peek().buildTearDownScriptBlock = $setup
+}

--- a/src/public/BuildTearDown.ps1
+++ b/src/public/BuildTearDown.ps1
@@ -4,7 +4,6 @@ function BuildTearDown {
         Adds a scriptblock that will be executed once at the end of the build
         .DESCRIPTION
         This function will accept a scriptblock that will be executed once at the end of the build, regardless of success or failure
-        The scriptblock accepts an optional parameter which describes the Task being setup.
         .PARAMETER setup
         A scriptblock to execute
         .EXAMPLE
@@ -42,10 +41,9 @@ function BuildTearDown {
         Executing task, Clean...
         Executing task, Compile...
         Executing task, Test...
-        Task failed : forced error
         Running 'BuildTearDown'
         forced error
-        At line:x char:x
+        At line:x char:x ...
         .LINK
         Assert
         .LINK

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -297,14 +297,19 @@ function Invoke-psake {
             & $currentContext.buildSetupScriptBlock
 
             # Execute the list of tasks or the default task
-            if ($taskList) {
-                foreach ($task in $taskList) {
-                    invoke-task $task
+            try {
+                if ($taskList) {
+                    foreach ($task in $taskList) {
+                        invoke-task $task
+                    }
+                } elseif ($currentContext.tasks.default) {
+                    invoke-task default
+                } else {
+                    throw $msgs.error_no_default_task
                 }
-            } elseif ($currentContext.tasks.default) {
-                invoke-task default
-            } else {
-                throw $msgs.error_no_default_task
+            }
+            finally {
+                & $currentContext.buildTearDownScriptBlock
             }
 
             $successMsg = $msgs.psake_success -f $buildFile

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -294,6 +294,8 @@ function Invoke-psake {
             # module's scope in order to initialize variables properly.
             . $module $initialization
 
+            & $currentContext.buildSetupScriptBlock
+
             # Execute the list of tasks or the default task
             if ($taskList) {
                 foreach ($task in $taskList) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Similar to TaskSetup and TaskTearDown, there are now functions to specify code snippets to be executed at the beginning of the build (before the first task), and at the end of the build (after either all tasks have completed, or a task has failed).

This is my first ever contribution to an opensource project, and first time using GitHub, so go easy on me :)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/psake/psake/issues/181

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In my implementation of psake, I need to perform some processing at the very beginning of the build, before any tasks run.

Previously, I had just worked around this using the TaskSetup functionality, and a variable to track whether the build setup had been performed. This approach isn't compatible with a change which I now want to make to our builds, which requires the build setup to have been performed before the task preconditions execute.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Windows 10 desktop. 
Powershell 5.1
.NET Framework 4.8
Pester 4.8.1
PlatyPS 0.14.0
PSScriptAnalyzer 1.18.1

Ran all existing Pester tests, and created some new ones for the new features. I wanted to write a Pester test that ensured the BuildTearDown executed even if the build failed, but I couldn't find a way of doing that which worked with the way the specs were executed.

So I had to do a manual test to verify that the BuildTearDown ran even if a task failed (and that the build still failed after the teardown had completed). Also manually tested that the build works when you don't specify BuildSetup or BuildTearDown. I used the new features in combination with TaskSetup and TaskTearDown to make sure everything was executing in the correct order.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
