### PR TITLE
In case of failure rerun command in specified location

### DIFF
--- a/specs/exec_executes_in_specified_location_should_pass.ps1
+++ b/specs/exec_executes_in_specified_location_should_pass.ps1
@@ -1,0 +1,22 @@
+Task default -depends Test
+
+Task Test {
+    [string[]]$global:locations = @()
+    [string[]]$expected = "env:\,variable:\,variable:\,variable:\,env:\"
+    [scriptblock]$cmd = {
+        $global:locations += Get-Location
+        throw "forced error"
+    }
+    Set-Location "env:"
+
+    $global:locations += Get-Location
+    try {
+        Exec -cmd $cmd -maxRetries 2 -workingDirectory "variable:"
+    }
+    catch {}
+    $global:locations += Get-Location
+
+     [string]$actual = $global:locations -join ","
+     $actual = $actual.ToLower()
+     Assert ($actual -eq $expected) "Expected: '$expected' Actual: '$actual'"
+}

--- a/specs/exec_executes_in_specified_location_should_pass.ps1
+++ b/specs/exec_executes_in_specified_location_should_pass.ps1
@@ -1,17 +1,18 @@
 Task default -depends Test
 
 Task Test {
+    [string]$currentPath = Get-Location
+    [string]$parentPath = Split-Path $currentPath -Parent
     [string[]]$global:locations = @()
-    [string[]]$expected = "env:\,variable:\,variable:\,variable:\,env:\"
+    [string[]]$expected = "$currentPath,$parentPath,$parentPath,$parentPath,$currentPath"
     [scriptblock]$cmd = {
         $global:locations += Get-Location
         throw "forced error"
     }
-    Set-Location "env:"
 
     $global:locations += Get-Location
     try {
-        Exec -cmd $cmd -maxRetries 2 -workingDirectory "variable:"
+        Exec -cmd $cmd -maxRetries 2 -workingDirectory $parentPath
     }
     catch {}
     $global:locations += Get-Location

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -65,14 +65,15 @@ function Exec {
         [string]$workingDirectory = $null
     )
 
-    if ($workingDirectory) {
-        Push-Location -Path $workingDirectory
-    }
-
     $tryCount = 1
 
     do {
         try {
+
+            if ($workingDirectory) {
+                Push-Location -Path $workingDirectory
+            }
+
             $global:lastexitcode = 0
             & $cmd
             if ($global:lastexitcode -ne 0) {


### PR DESCRIPTION
In case of command failure retry running command on he location passed by caller

## Description
Lets say caller wan't to Exec deletion of all files inside D:\ folder and retry it max 10 times.
We are running script in E:\ folder
Old/current code would have changed location to E:\ (correctly), try and fail on deleting all files and will pop location back to E:\
Next 9 attempts will run inside E:\
Now we will push and pop on each attempt

## Related Issue
Mistake was in #200 

## Motivation and Context
Mentioned in description

## How Has This Been Tested?
Because this is an easy fix I just tested in small sample build script

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
