### PR TITLE
Enabling String and FileInfo Objects To Be Piped To Include Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Changed
 
+- [**#290**](https://github.com/psake/psake/pull/290) Enabling String and
+  FileInfo Objects To Be Piped To Include Function
 - [**#301**](https://github.com/psake/psake/pull/301) Add ability to override
   psake's internal logging.
 

--- a/specs/include_can_process_fileinfo_from_pipeline_should_pass.ps1
+++ b/specs/include_can_process_fileinfo_from_pipeline_should_pass.ps1
@@ -1,0 +1,18 @@
+[string[]]$files = @("TestFile1.ps1","TestFile2.ps1");
+
+Out-File -FilePath "TestFile1.ps1" -InputObject "function Test-Function1 { return 1; }";
+Out-File -FilePath "TestFile2.ps1" -InputObject "function Test-Function2 { return 2; }";
+
+$files | Get-Item | Include;
+
+Task default -depends Test;
+
+BuildTearDown {
+    @("TestFile1.ps1","TestFile2.ps1","Function:\Test-Function1","Function:\Test-Function2") | ForEach-Object {Remove-Item $_;} | Out-Null;
+}
+
+Task Test {
+    Assert ($(Test-Path "Function:\Test-Function1") -ne $null) "Test-Function1 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function2") -ne $null) "Test-Function2 is not accessible";
+}
+

--- a/specs/include_can_process_fileinfo_from_pipeline_should_pass.ps1
+++ b/specs/include_can_process_fileinfo_from_pipeline_should_pass.ps1
@@ -12,7 +12,7 @@ BuildTearDown {
 }
 
 Task Test {
-    Assert ($(Test-Path "Function:\Test-Function1") -ne $null) "Test-Function1 is not accessible";
-    Assert ($(Test-Path "Function:\Test-Function2") -ne $null) "Test-Function2 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function1")) "Test-Function1 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function2")) "Test-Function2 is not accessible";
 }
 

--- a/specs/include_can_process_strings_from_pipeline_should_pass.ps1
+++ b/specs/include_can_process_strings_from_pipeline_should_pass.ps1
@@ -1,0 +1,18 @@
+[string[]]$files = @("TestFile1.ps1","TestFile2.ps1");
+
+Out-File -FilePath "TestFile1.ps1" -InputObject "function Test-Function1 { return 1; }";
+Out-File -FilePath "TestFile2.ps1" -InputObject "function Test-Function2 { return 2; }";
+
+$files | Include;
+
+Task default -depends Test;
+
+BuildTearDown {
+    @("TestFile1.ps1","TestFile2.ps1","Function:\Test-Function1","Function:\Test-Function2") | ForEach-Object {Remove-Item $_;} | Out-Null;
+}
+
+Task Test {
+    Assert ($(Test-Path "Function:\Test-Function1") -ne $null) "Test-Function1 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function2") -ne $null) "Test-Function2 is not accessible";
+}
+

--- a/specs/include_can_process_strings_from_pipeline_should_pass.ps1
+++ b/specs/include_can_process_strings_from_pipeline_should_pass.ps1
@@ -12,7 +12,7 @@ BuildTearDown {
 }
 
 Task Test {
-    Assert ($(Test-Path "Function:\Test-Function1") -ne $null) "Test-Function1 is not accessible";
-    Assert ($(Test-Path "Function:\Test-Function2") -ne $null) "Test-Function2 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function1")) "Test-Function1 is not accessible";
+    Assert ($(Test-Path "Function:\Test-Function2")) "Test-Function2 is not accessible";
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
You can now do this : 
```
$("File1.ps1","File2.ps1") | Include
Get-ChildItem | Include
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#289 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows users to write slightly more concise code, rather than writing for loops.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New Pester tests have been added to verify that it can accept pipeline input both in the form of strings and FileInfo objects.

I also manually tested that it was backwards compatible, and could still work with the fileNamePathToInclude parameter.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
