### PR TITLE
Support limited parameter passing to build script

### DIFF
--- a/src/private/ExecuteInBuildFileScope.ps1
+++ b/src/private/ExecuteInBuildFileScope.ps1
@@ -1,5 +1,5 @@
 function ExecuteInBuildFileScope {
-    param([string]$buildFile, $module, [scriptblock]$sb)
+    param([string]$buildFile, $module, $buildScriptArguments, [scriptblock]$sb)
 
     # Execute the build file to set up the tasks and defaults
     Assert (test-path $buildFile -pathType Leaf) ($msgs.error_build_file_not_found -f $buildFile)
@@ -11,17 +11,17 @@ function ExecuteInBuildFileScope {
     # Create a new psake context
     $psake.context.push(
         @{
-            "buildSetupScriptBlock"         = {}
-            "buildTearDownScriptBlock"      = {}
-            "taskSetupScriptBlock"          = {}
-            "taskTearDownScriptBlock"       = {}
+            "buildSetupScriptBlock"         = { }
+            "buildTearDownScriptBlock"      = { }
+            "taskSetupScriptBlock"          = { }
+            "taskTearDownScriptBlock"       = { }
             "executedTasks"                 = new-object System.Collections.Stack
             "callStack"                     = new-object System.Collections.Stack
             "originalEnvPath"               = $env:PATH
             "originalDirectory"             = get-location
             "originalErrorActionPreference" = $global:ErrorActionPreference
-            "tasks"                         = @{}
-            "aliases"                       = @{}
+            "tasks"                         = @{ }
+            "aliases"                       = @{ }
             "properties"                    = new-object System.Collections.Stack
             "includes"                      = new-object System.Collections.Queue
             "config"                        = CreateConfigurationForNewContext $buildFile $framework
@@ -37,8 +37,7 @@ function ExecuteInBuildFileScope {
     LoadModules
 
     $frameworkOldValue = $framework
-
-    . $psake.build_script_file.FullName
+    . $psake.build_script_file.FullName @buildScriptArguments
 
     $currentContext = $psake.context.Peek()
 

--- a/src/psake.ps1
+++ b/src/psake.ps1
@@ -4,7 +4,7 @@
 
 # Must match parameter definitions for psake.psm1/invoke-psake
 # otherwise named parameter binding fails
-[cmdletbinding()]
+[cmdletbinding(PositionalBinding = $false)]
 param(
     [Parameter(Position = 0, Mandatory = $false)]
     [string]$buildFile,
@@ -12,36 +12,39 @@ param(
     [Parameter(Position = 1, Mandatory = $false)]
     [string[]]$taskList = @(),
 
-    [Parameter(Position = 2, Mandatory = $false)]
+    [Parameter(Mandatory = $false)]
     [string]$framework,
 
-    [Parameter(Position = 3, Mandatory = $false)]
+    [Parameter(Mandatory = $false)]
     [switch]$docs = $false,
 
-    [Parameter(Position = 4, Mandatory = $false)]
-    [System.Collections.Hashtable]$parameters = @{},
+    [Parameter(Mandatory = $false)]
+    [hashtable]$parameters = @{ },
 
-    [Parameter(Position = 5, Mandatory = $false)]
-    [System.Collections.Hashtable]$properties = @{},
+    [Parameter(Mandatory = $false)]
+    [hashtable]$properties = @{ },
 
-    [Parameter(Position = 6, Mandatory = $false)]
+    [Parameter(Mandatory = $false)]
     [alias("init")]
-    [scriptblock]$initialization = {},
+    [scriptblock]$initialization = { },
 
-    [Parameter(Position = 7, Mandatory = $false)]
+    [Parameter(Mandatory = $false)]
     [switch]$nologo = $false,
 
-    [Parameter(Position = 8, Mandatory = $false)]
-    [switch]$help = $false,
-
-    [Parameter(Position = 9, Mandatory = $false)]
-    [string]$scriptPath,
-
-    [Parameter(Position = 10, Mandatory = $false)]
+    [Parameter(Mandatory = $false)]
     [switch]$detailedDocs = $false,
 
-    [Parameter(Position = 11, Mandatory = $false)]
-    [switch]$notr = $false
+    [Parameter(Mandatory = $false)]
+    [switch]$notr = $false,
+
+    [Parameter(Mandatory = $false, ValueFromRemainingArguments = $true)]
+    $buildScriptArguments = $null,
+
+    [Parameter(Mandatory = $false)]
+    [switch]$help = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string]$scriptPath
 )
 
 # setting $scriptPath here, not as default argument, to support calling as "powershell -File psake.ps1"
@@ -64,7 +67,7 @@ if ($buildFile -and (-not (Test-Path -Path $buildFile))) {
     }
 }
 
-Invoke-psake $buildFile $taskList $framework $docs $parameters $properties $initialization $nologo $detailedDocs $notr
+Invoke-psake $buildFile $taskList -framework $framework -docs:$docs -parameters $parameters -properties $properties -init $initialization -nologo:$nologo -detailedDocs:$detailedDocs -notr:$notr $buildScriptArguments
 
 if (!$psake.build_success) {
     exit 1


### PR DESCRIPTION
The support is limited, as it works only for named parameters,
and do not support [switch] parameters. For that maybe the
PowerShell dynamic parameters could be used...

FIrst version, need some cleanup, but wondering if anyone believe this is the right approach?

To test create script like:

```powershell
param(
    $arg1 = "it does not work"
)

task default -depends Hello

task Hello {
    write-host "arg1: $arg1"
}
```

And run it!

```powershell
psake -arg1 "it works!"
```