### PR TITLE
Fix continueonerror

### DIFF
--- a/specs/invoketask_with_continueonerror_should_pass.ps1
+++ b/specs/invoketask_with_continueonerror_should_pass.ps1
@@ -1,0 +1,11 @@
+Task Default -Depends Test-DoesntFailBuildWhenTaskWritesToStandardError,Test-DoesntFailBuildWhenTaskThrowsException,Test-DoesntFailBuildWhenTaskIsSuccessful
+
+Task Test-DoesntFailBuildWhenTaskWritesToStandardError -ContinueOnError {
+    Write-Error "Task 1"
+}
+
+Task Test-DoesntFailBuildWhenTaskThrowsException -ContinueOnError {
+    Throw "Task 2"
+}
+
+Task Test-DoesntFailBuildWhenTaskIsSuccessful -ContinueOnError {}

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -129,7 +129,6 @@ function Invoke-Task {
                         "-"*70
                         WriteColoredOutput ($msgs.continue_on_error -f $taskName,$_) -foregroundcolor Yellow
                         "-"*70
-                        [void]$currentContext.callStack.Pop()
                     }  else {
                         throw $_
                     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Created a Pester test to assert that the -ContinueOnError parameter has the desired behaviour.
2. Removed the additional call stack pop from Invoke-Task, which was causing that test to fail.
3. Added a try...finally to Invoke-Task immediately after the task is pushed onto the stack. The finally block ensures that the task is always popped, even if the task fails. This resolved a new bug which surfaced, where if a task with -ContinueOnError depends on another task, which fails, the failed task would not pop itself from the stack, and when the dependent task tried to pop itself from the stack, it would actually pop the failed task, causing a validation error.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#295

## Motivation and Context
As described in the issue, this is an issue which has broken a feature which previously worked.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a new Pester test, and ran all existing tests locally.

Tested on Windows 10, Powershell 5.1.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
