### PR TITLE
Ability to override how psake's internal logging is handled

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://github.com/DavidAnson/markdownlint/blob/main/schema/markdownlint-config-schema.json",
+    "MD024": {
+        "siblings_only": true
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
   "search.exclude": {
     "?.?.?/": true
   },
-  "powershell.codeFormatting.preset": "OTBS"
+  "powershell.codeFormatting.preset": "OTBS",
+  "powershell.codeFormatting.alignPropertyValuePairs": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,42 +5,65 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+## Changed
+
+- [**#301**](https://github.com/psake/psake/pull/301) Add ability to override
+  psake's internal logging.
+
 ## [4.9.1] 2024-10-06
 
 ### Fixed
 
-- [**#296**](https://github.com/psake/psake/pull/296) Fix `-ContinueOnError` functionality (via [@UberDoodles](https://github.com/UberDoodles))
-- Required variables set on a task are now validated even if the task has no action defined.
+- [**#296**](https://github.com/psake/psake/pull/296) Fix `-ContinueOnError`
+  functionality (via [@UberDoodles](https://github.com/UberDoodles))
+- Required variables set on a task are now validated even if the task has no
+  action defined.
 
 ### Improvements
 
-- [**#297**](https://github.com/psake/psake/pull/297) Enable type conversion when passing properties (via [@whut](https://github.com/whut))
-- [**#303**](https://github.com/psake/psake/pull/303) Add alias `wd` for `workingDirectory` on the `exec` command (via [@SeidChr](https://github.com/SeidChr))
-- [**#326**](https://github.com/psake/psake/pull/326) Add support for MS Build 17 support (included with Visual Studio 2022). (via [Thorarin](https://github.com/Thorarin))
-- Parameters are now PascalCase instead of camelCase (via [Splaxi](https://github.com/Splaxi))
-   - Task [**#314**](https://github.com/psake/psake/pull/314)
-   - TaskSetup [**#316**](https://github.com/psake/psake/pull/316)
-   - TaskTearDown [**#317**](https://github.com/psake/psake/pull/317)
-   - Assert [**#318**](https://github.com/psake/psake/pull/318)
-   - BuildSetup [**#319**](https://github.com/psake/psake/pull/319)
-   - BuildTearDown [**#320**](https://github.com/psake/psake/pull/320)
-   - Exec [**#321**](https://github.com/psake/psake/pull/321)
-   - FormatTaskName [**#322**](https://github.com/psake/psake/pull/322)
-   - Framework [**#323**](https://github.com/psake/psake/pull/323)
-   - Get-PsakeScriptTasks [**#324**](https://github.com/psake/psake/pull/324)
+- [**#297**](https://github.com/psake/psake/pull/297) Enable type conversion
+  when passing properties (via [@whut](https://github.com/whut))
+- [**#303**](https://github.com/psake/psake/pull/303) Add alias `wd` for
+  `workingDirectory` on the `exec` command (via
+  [@SeidChr](https://github.com/SeidChr))
+- [**#326**](https://github.com/psake/psake/pull/326) Add support for MS Build
+  17 support (included with Visual Studio 2022). (via
+  [Thorarin](https://github.com/Thorarin))
+- Parameters are now PascalCase instead of camelCase (via
+  [Splaxi](https://github.com/Splaxi))
+  - Task [**#314**](https://github.com/psake/psake/pull/314)
+  - TaskSetup [**#316**](https://github.com/psake/psake/pull/316)
+  - TaskTearDown [**#317**](https://github.com/psake/psake/pull/317)
+  - Assert [**#318**](https://github.com/psake/psake/pull/318)
+  - BuildSetup [**#319**](https://github.com/psake/psake/pull/319)
+  - BuildTearDown [**#320**](https://github.com/psake/psake/pull/320)
+  - Exec [**#321**](https://github.com/psake/psake/pull/321)
+  - FormatTaskName [**#322**](https://github.com/psake/psake/pull/322)
+  - Framework [**#323**](https://github.com/psake/psake/pull/323)
+  - Get-PsakeScriptTasks [**#324**](https://github.com/psake/psake/pull/324)
 
 ## [4.9.0] 2019-09-21
 
 ### Fixed
 
 - Fix hashtable references so strict mode works when set in the psakeFile.
-- [**#283**](https://github.com/psake/psake/pull/283) Fix path issue for msbuild is VS 2019. (via [@jaymclain](https://github.com/jaymclain))
-- [**#287**](https://github.com/psake/psake/pull/287) In `Exec` function, always rerun command in specified location (via [@tiksn](https://github.com/tiksn) and [@UberDoodles](https://github.com/UberDoodles))
+- [**#283**](https://github.com/psake/psake/pull/283) Fix path issue for msbuild
+  is VS 2019. (via [@jaymclain](https://github.com/jaymclain))
+- [**#287**](https://github.com/psake/psake/pull/287) In `Exec` function, always
+  rerun command in specified location (via [@tiksn](https://github.com/tiksn)
+  and [@UberDoodles](https://github.com/UberDoodles))
 
 ### Added
 
-- [**#281**](https://github.com/psake/psake/pull/281) Support for .Net 4.8 in `Framework` function (via [@granit1986](https://github.com/granit1986))
-- [**#285**](https://github.com/psake/psake/pull/285) Add BuildSetup and BuildTearDown functions that are executed at the beginning of the build (before the first task), and at the end of the build (after either all tasks have completed, or a task has failed). (via [@UberDoodles](https://github.com/UberDoodles))
+- [**#281**](https://github.com/psake/psake/pull/281) Support for .Net 4.8 in
+  `Framework` function (via [@granit1986](https://github.com/granit1986))
+- [**#285**](https://github.com/psake/psake/pull/285) Add BuildSetup and
+  BuildTearDown functions that are executed at the beginning of the build
+  (before the first task), and at the end of the build (after either all tasks
+  have completed, or a task has failed). (via
+  [@UberDoodles](https://github.com/UberDoodles))
 
 ## [4.8.0] 2019-04-23
 
@@ -50,29 +73,45 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
-- [**#267**](https://github.com/psake/psake/pull/267) Add wrapper script for Linux and macOS. (via [@dermeister0](https://github.com/dermeister0))
+- [**#267**](https://github.com/psake/psake/pull/267) Add wrapper script for
+  Linux and macOS. (via [@dermeister0](https://github.com/dermeister0))
 
-- [**#268**](https://github.com/psake/psake/pull/268) Allow more granularity when specifying versions of modules to load when referencing shared tasks (via [@RandomNoun7](https://github.com/RandomNoun7))
+- [**#268**](https://github.com/psake/psake/pull/268) Allow more granularity
+  when specifying versions of modules to load when referencing shared tasks (via
+  [@RandomNoun7](https://github.com/RandomNoun7))
 
-- [**#274**](https://github.com/psake/psake/pull/274) Add support for Visual Studio 2019 and MSBuild 16.0. (via [@petedavis](https://github.com/petedavis))
+- [**#274**](https://github.com/psake/psake/pull/274) Add support for Visual
+  Studio 2019 and MSBuild 16.0. (via
+  [@petedavis](https://github.com/petedavis))
 
-- [**#276**](https://github.com/psake/psake/pull/276) Pass task detail including error information into TaskSetup and TaskTearDown. (via [@davidalpert](https://github.com/davidalpert))
+- [**#276**](https://github.com/psake/psake/pull/276) Pass task detail including
+  error information into TaskSetup and TaskTearDown. (via
+  [@davidalpert](https://github.com/davidalpert))
 
 ### Fixed
 
-- [**#272**](https://github.com/psake/psake/pull/272) Improve parameter initialization error handling to include the parameter name which caused failure (via [@GreatTeacherBasshead](https://github.com/GreatTeacherBasshead))
+- [**#272**](https://github.com/psake/psake/pull/272) Improve parameter
+  initialization error handling to include the parameter name which caused
+  failure (via
+  [@GreatTeacherBasshead](https://github.com/GreatTeacherBasshead))
 
 ## [4.7.4] 2018-09-07
 
 ### Fixed
 
-- [**#260**](https://github.com/psake/psake/pull/260) Change the build time report to show individual task durations instead of cumulative (via [@sideproject](https://github.com/sideproject))
+- [**#260**](https://github.com/psake/psake/pull/260) Change the build time
+  report to show individual task durations instead of cumulative (via
+  [@sideproject](https://github.com/sideproject))
 
-- [**#261**](https://github.com/psake/psake/pull/261) Use `$global:lastexitcode` instead of `$lastexitcode` in Exec (via [@gpetrou](https://github.com/gpetrou))
+- [**#261**](https://github.com/psake/psake/pull/261) Use `$global:lastexitcode`
+  instead of `$lastexitcode` in Exec (via
+  [@gpetrou](https://github.com/gpetrou))
 
 ### Improvements
 
-- [**#259**](https://github.com/psake/psake/pull/259) Add $psake.error_message property which contains the error message that cause the build to fail (via [@sideproject](https://github.com/sideproject))
+- [**#259**](https://github.com/psake/psake/pull/259) Add $psake.error_message
+  property which contains the error message that cause the build to fail (via
+  [@sideproject](https://github.com/sideproject))
 
 ## [4.7.3] 2018-08-11
 
@@ -84,67 +123,99 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
-- [**#257**](https://github.com/psake/psake/pull/257) Add support for .Net 4.7.2 (via [@dawoodmm](https://github.com/dawoodmm))
+- [**#257**](https://github.com/psake/psake/pull/257) Add support for .Net 4.7.2
+  (via [@dawoodmm](https://github.com/dawoodmm))
 
 ## [4.7.1] 2018-07-03
 
 ### Improvements
 
-- [**#244**](https://github.com/psake/psake/pull/244) Update build success message to be more general: psake succeeded (via [@rkeithhill](https://github.com/rkeithhill))
-- [**#249**](https://github.com/psake/psake/pull/249) Allow working with preloaded VSSetup module (via [@havranek1024](https://github.com/havranek1024))
+- [**#244**](https://github.com/psake/psake/pull/244) Update build success
+  message to be more general: psake succeeded (via
+  [@rkeithhill](https://github.com/rkeithhill))
+- [**#249**](https://github.com/psake/psake/pull/249) Allow working with
+  preloaded VSSetup module (via
+  [@havranek1024](https://github.com/havranek1024))
 
 ### Fixed
 
-- [**#236**](https://github.com/psake/psake/pull/236) Change check for `$IsWindows` so it doesn't generate an error record (via [@rkeithhill](https://github.com/rkeithhill))
+- [**#236**](https://github.com/psake/psake/pull/236) Change check for
+  `$IsWindows` so it doesn't generate an error record (via
+  [@rkeithhill](https://github.com/rkeithhill))
 
 ## [4.7.0] 2017-11-21
 
-As part of this release we had [13 issues](https://github.com/psake/psake/issues?q=milestone%3Av4.7.0+is%3Aclosed) closed.
+As part of this release we had
+[13 issues](https://github.com/psake/psake/issues?q=milestone%3Av4.7.0+is%3Aclosed)
+closed.
 
 ### Features
 
-- [**#198**](https://github.com/psake/psake/pull/198) Add support for PowerShell Core on macOS and Linux. (via [@dbroeglin](https://github.com/dbroeglin))
+- [**#198**](https://github.com/psake/psake/pull/198) Add support for PowerShell
+  Core on macOS and Linux. (via [@dbroeglin](https://github.com/dbroeglin))
 
-- [**#196**](https://github.com/psake/psake/pull/196) Deprecate default build script name `default.ps1` in favor of `psakefile.ps1`. (via [@glennsarti](https://github.com/glennsarti))
+- [**#196**](https://github.com/psake/psake/pull/196) Deprecate default build
+  script name `default.ps1` in favor of `psakefile.ps1`. (via
+  [@glennsarti](https://github.com/glennsarti))
 
 - Remove legacy PowerShell v2 support. PSake now supports v3 and above.
 
 ### Improvements
 
-- [**#228**](https://github.com/psake/psake/pull/228) Project structure refactor (via [@devblackops](https://github.com/devblackops))
+- [**#228**](https://github.com/psake/psake/pull/228) Project structure refactor
+  (via [@devblackops](https://github.com/devblackops))
 
-- [**#227**](https://github.com/psake/psake/pull/227) Ensure postAction and taskTeardown tasks get called after action failure (via [@stephan-dowding](https://github.com/stephan-dowding))
+- [**#227**](https://github.com/psake/psake/pull/227) Ensure postAction and
+  taskTeardown tasks get called after action failure (via
+  [@stephan-dowding](https://github.com/stephan-dowding))
 
-- [**#222**](https://github.com/psake/psake/pull/222) Add support for .Net frameworks 4.6.2, 4.7, and 4.7.1. (via [@rkeithhill](https://github.com/rkeithhill))
+- [**#222**](https://github.com/psake/psake/pull/222) Add support for .Net
+  frameworks 4.6.2, 4.7, and 4.7.1. (via
+  [@rkeithhill](https://github.com/rkeithhill))
 
-- [**#218**](https://github.com/psake/psake/pull/218) Improve Build Time Report by using custom `FormatTaskName` value for header and display task timing at millisecond accuracy instead of microsecond. (via [@theunrepentantgeek](https://github.com/theunrepentantgeek))
+- [**#218**](https://github.com/psake/psake/pull/218) Improve Build Time Report
+  by using custom `FormatTaskName` value for header and display task timing at
+  millisecond accuracy instead of microsecond. (via
+  [@theunrepentantgeek](https://github.com/theunrepentantgeek))
 
-- [**#200**](https://github.com/psake/psake/pull/200) Add `WorkingDirectory` parameter to `Exec` function. (via [@DaveSenn](https://github.com/DaveSenn))
+- [**#200**](https://github.com/psake/psake/pull/200) Add `WorkingDirectory`
+  parameter to `Exec` function. (via [@DaveSenn](https://github.com/DaveSenn))
 
-- [**#190**](https://github.com/psake/psake/pull/190) Use `WriteColoredOutput` for all task headers. (via [@damianpowell](https://github.com/damianpowell))
+- [**#190**](https://github.com/psake/psake/pull/190) Use `WriteColoredOutput`
+  for all task headers. (via [@damianpowell](https://github.com/damianpowell))
 
 ## [4.6.0] 2016-03-20
 
-As part of this release we had [6 issues](https://github.com/psake/psake/issues?milestone=6&state=closed) closed.
+As part of this release we had
+[6 issues](https://github.com/psake/psake/issues?milestone=6&state=closed)
+closed.
 
 ### Fixed
 
-- [**#149**](https://github.com/psake/psake/pull/149) Using ErrorAction Ignore in PSv3+
+- [**#149**](https://github.com/psake/psake/pull/149) Using ErrorAction Ignore
+  in PSv3+
 
 ### Features
 
-- [**#153**](https://github.com/psake/psake/issues/153) Invoke-psake with option to return documentation should return objects instead of formated string
-- [**#147**](https://github.com/psake/psake/pull/147) Added an option '-notr' to disable output of time report.
-- [**#143**](https://github.com/psake/psake/issues/143) Publish Psake on PowerShellGallery
+- [**#153**](https://github.com/psake/psake/issues/153) Invoke-psake with option
+  to return documentation should return objects instead of formated string
+- [**#147**](https://github.com/psake/psake/pull/147) Added an option '-notr' to
+  disable output of time report.
+- [**#143**](https://github.com/psake/psake/issues/143) Publish Psake on
+  PowerShellGallery
 
 ### Improvements
 
-- [**#155**](https://github.com/psake/psake/issues/155) Move wiki content to readthedocs
-- [**#152**](https://github.com/psake/psake/pull/152) Adding an example for a parallel task
-- [**#138**](https://github.com/psake/psake/pull/138) Cleanup MaxRetries and RetryTriggerErrorPattern in the context of Task. (#117 and #103)
+- [**#155**](https://github.com/psake/psake/issues/155) Move wiki content to
+  readthedocs
+- [**#152**](https://github.com/psake/psake/pull/152) Adding an example for a
+  parallel task
+- [**#138**](https://github.com/psake/psake/pull/138) Cleanup MaxRetries and
+  RetryTriggerErrorPattern in the context of Task. (#117 and #103)
 
 ## [4.5.0] 2015-12-12
 
 ### Improvements
 
-- [**#141**](https://github.com/psake/psake/pull/141) Added support for .NET 4.6.1
+- [**#141**](https://github.com/psake/psake/pull/141) Added support for .NET
+  4.6.1

--- a/docs/customising-logging.md
+++ b/docs/customising-logging.md
@@ -1,0 +1,38 @@
+By default, psake writes messages to the pipeline, where they typically end up displayed in the console window or the logs of a CI tool. However, sometimes you may want to handle output differently. Perhaps to ensure the psake messages are displayed or logged in a way which is consistent with the logging of your build scripts.
+
+The code which controls how various messages are output are now exposed in the psake config, and can be overriden in two ways.
+
+# Overriding A Specific Message Type
+
+Each message that psake outputs is assigned a type such as "warning", "debug" or "default". Each type has it's own outputHandler script block in the psake config, which takes a single $output parameter. So you can change how a particular type of message is output by overriding them in the psake-config.ps1 file like so :
+
+```powershell
+$config.outputHandlers.default = {Param([object]$output) Write-Output "$(Get-Date -format "yyyy-MM-dd HH:mm:ss"): $output"}
+$config.outputHandlers.warning = {Param([object]$output) CustomFunction "$(Get-Date -format "yyyy-MM-dd HH:mm:ss"): $output"}
+```
+
+This example prefixes all default and warning messages with a date and timestamp, and the warning messages are sent to a custom function defined in the build file.
+
+# Overriding The outputHandler
+
+The process of routing various types of message to the output handlers is performed by an outputHandler script block in the psake config.
+
+However, if the default behaviour of routing messages to handlers based on their type doesn't work for you, you can also override the outputHandler itself, like so :
+
+```powershell
+$config.outputHandler = {
+    [CmdLetBinding()]
+    Param (
+        [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [object]$Output,
+        [Parameter(Position=1,ValueFromPipelineByPropertyName=$true)]
+        [string]$OutputType = "default"
+    )
+
+    Process {
+        CustomFunction $Output $OutputType
+    }
+ };
+```
+
+This example routes all messages, regardless of $OutputType, to a custom function.

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -1,5 +1,0 @@
-Task default -depends Test-Task
-
-Task Test-Task {
-    Write-Output "Test 1"
-}

--- a/psakeFile.ps1
+++ b/psakeFile.ps1
@@ -1,0 +1,5 @@
+Task default -depends Test-Task
+
+Task Test-Task {
+    Write-Output "Test 1"
+}

--- a/specs/outputHandler_routes_messages_to_specified_handler_type_should_pass.ps1
+++ b/specs/outputHandler_routes_messages_to_specified_handler_type_should_pass.ps1
@@ -1,0 +1,8 @@
+task default -depends CheckMessagesRoutedCorrectly
+
+task CheckMessagesRoutedCorrectly {
+    [string[]]$output = Invoke-psake ".\outputhandler_routes_messages_to_specified_handler_type\outputhandler_routes_messages_to_specified_handler_type.ps1"
+    [string[]]$outputType = @("heading","default","debug","warning","error","success")
+
+    $outputType | ForEach-Object {Assert ($output -contains "$_ : $_") "Message with type '$_' was not routed to the relevant outputHandler"}
+}

--- a/specs/outputhandler_routes_messages_to_specified_handler_type/outputhandler_routes_messages_to_specified_handler_type.ps1
+++ b/specs/outputhandler_routes_messages_to_specified_handler_type/outputhandler_routes_messages_to_specified_handler_type.ps1
@@ -1,0 +1,10 @@
+task default -depends TaskA
+
+task TaskA {
+    WriteOutput "heading" "heading"
+    WriteOutput "default" "default"
+    WriteOutput "debug" "debug"
+    WriteOutput "warning" "warning"
+    WriteOutput "error" "error"
+    WriteOutput "success" "success"
+}

--- a/specs/outputhandler_routes_messages_to_specified_handler_type/psake-config.ps1
+++ b/specs/outputhandler_routes_messages_to_specified_handler_type/psake-config.ps1
@@ -1,0 +1,7 @@
+$config.outputHandlers.heading = { Param($output) Write-Output "heading : $output" };
+$config.outputHandlers.default = { Param($output) Write-Output "default : $output" };
+$config.outputHandlers.debug = { Param($output) Write-Output "debug : $output" };
+$config.outputHandlers.warning = { Param($output) Write-Output "warning : $output" };
+$config.outputHandlers.error = { Param($output) Write-Output "error : $output" };
+$config.outputHandlers.success = { Param($output) Write-Output "success : $output" };
+$config.verboseError = $true;

--- a/specs/outputhandler_routes_unknown_message_type_to_default_handler/outputhandler_routes_unknown_message_type_to_default_handler.ps1
+++ b/specs/outputhandler_routes_unknown_message_type_to_default_handler/outputhandler_routes_unknown_message_type_to_default_handler.ps1
@@ -1,0 +1,11 @@
+task default -depends TaskA
+
+task TaskA {
+    WriteOutput "heading" "heading"
+    WriteOutput "default" "default"
+    WriteOutput "debug" "debug"
+    WriteOutput "warning" "warning"
+    WriteOutput "error" "error"
+    WriteOutput "success" "success"
+    WriteOutput "other" "other"
+}

--- a/specs/outputhandler_routes_unknown_message_type_to_default_handler/psake-config.ps1
+++ b/specs/outputhandler_routes_unknown_message_type_to_default_handler/psake-config.ps1
@@ -1,0 +1,6 @@
+$config.outputHandlers.heading = $null
+$config.outputHandlers.default = { Param($output) Write-Output "default : $output" };
+$config.outputHandlers.debug = $null
+$config.outputHandlers.warning = $null
+$config.outputHandlers.error = $null
+$config.outputHandlers.success = $null

--- a/specs/outputhandler_routes_unknown_message_type_to_default_handler_should_pass.ps1
+++ b/specs/outputhandler_routes_unknown_message_type_to_default_handler_should_pass.ps1
@@ -1,0 +1,8 @@
+task default -depends CheckMessagesRoutedToDefault
+
+task CheckMessagesRoutedToDefault {
+    [string[]]$output = Invoke-psake ".\outputhandler_routes_unknown_message_type_to_default_handler\outputhandler_routes_unknown_message_type_to_default_handler.ps1" 3>&1
+    [string[]]$outputType = @("heading","default","debug","warning","error","success","other")
+
+    $outputType | ForEach-Object {Assert ($output -contains "default : $_") "Message with type '$_' was not re-routed to the default outputHandler"}
+}

--- a/specs/use_writeoutput_function_throughout/psake-config.ps1
+++ b/specs/use_writeoutput_function_throughout/psake-config.ps1
@@ -1,0 +1,13 @@
+$config.outputHandler = {
+    [CmdLetBinding()]
+    Param (
+        [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [object]$Output,
+        [Parameter(Position=1,ValueFromPipelineByPropertyName=$true)]
+        [string]$OutputType = "default"
+    )
+
+    Process {
+        Write-Output "WriteOutput: $OutputType : $Output"
+    }
+};

--- a/specs/use_writeoutput_function_throughout/use_writeoutput_function_throughout.ps1
+++ b/specs/use_writeoutput_function_throughout/use_writeoutput_function_throughout.ps1
@@ -1,0 +1,7 @@
+task default -depends Task1
+
+task TaskA -alias Task1 -preaction { "something" | Out-Null } -postaction {"something" | Out-Null} -precondition {1 -eq 1} {"something" | Out-Null}
+
+task TaskB -precondition {0 -eq 1} {}
+
+task TaskC -continueonerror {throw "Forced error"}

--- a/specs/use_writeoutput_function_throughout_should_pass.ps1
+++ b/specs/use_writeoutput_function_throughout_should_pass.ps1
@@ -1,0 +1,19 @@
+task default -depends CheckAllOutputViaOutputHandler,CheckAllOutputViaOutputHandler_Docs
+
+task CheckAllOutputViaOutputHandler {
+    [string[]]$output = Invoke-psake ".\use_writeoutput_function_throughout\use_writeoutput_function_throughout.ps1" -properties @{Property1="A";Property2="B"} -parameters @{Param1="ParamA";Param2="ParamB"} -nologo
+    [string[]]$outputNotFromWriteOutput = $output | Where-Object {$_.Substring(0,12) -ne "WriteOutput:"}
+
+    if ($outputNotFromWriteOutput.Length -gt 0) {
+        Throw "The following output was not routed via WriteOutput:`n $outputNotFromWriteOutput"
+    }
+}
+
+task CheckAllOutputViaOutputHandler_Docs {
+    [string[]]$output = Invoke-psake ".\use_writeoutput_function_throughout\use_writeoutput_function_throughout.ps1" -nologo -docs
+    [string[]]$outputNotFromWriteOutput = $output | Where-Object {$_.Substring(0,12) -ne "WriteOutput:"}
+
+    if ($outputNotFromWriteOutput.Length -gt 0) {
+        Throw "The following output was not routed via WriteOutput:`n $outputNotFromWriteOutput"
+    }
+}

--- a/src/private/ConfigureBuildEnvironment.ps1
+++ b/src/private/ConfigureBuildEnvironment.ps1
@@ -97,7 +97,7 @@ function ConfigureBuildEnvironment {
                 if ($ver -eq "15.0") {
                     if ($null -eq (Get-Module -Name VSSetup)) {
                         if ($null -eq (Get-Module -Name VSSetup -ListAvailable)) {
-                            WriteColoredOutput ($msgs.warning_missing_vsssetup_module -f $ver) -foregroundcolor Yellow
+                            WriteOutput ($msgs.warning_missing_vsssetup_module -f $ver) "warning"
                             continue
                         }
 
@@ -145,7 +145,7 @@ function ConfigureBuildEnvironment {
                 elseif ($ver -eq "16.0") {
                     if ($null -eq (Get-Module -Name VSSetup)) {
                         if ($null -eq (Get-Module -Name VSSetup -ListAvailable)) {
-                            WriteColoredOutput ($msgs.warning_missing_vsssetup_module -f $ver) -foregroundcolor Yellow
+                            WriteOutput ($msgs.warning_missing_vsssetup_module -f $ver) "warning"
                             continue
                         }
 

--- a/src/private/CreateConfigurationForNewContext.ps1
+++ b/src/private/CreateConfigurationForNewContext.ps1
@@ -14,6 +14,8 @@ function CreateConfigurationForNewContext {
         coloredOutput = $previousConfig.coloredOutput;
         modules = $previousConfig.modules;
         moduleScope =  $previousConfig.moduleScope;
+        outputHandler = $previousConfig.outputHandler;
+        outputHandlers = $previousConfig.outputHandlers;
     }
 
     if ($framework) {

--- a/src/private/CreateConfigurationForNewContext.ps1
+++ b/src/private/CreateConfigurationForNewContext.ps1
@@ -15,7 +15,7 @@ function CreateConfigurationForNewContext {
         modules = $previousConfig.modules;
         moduleScope =  $previousConfig.moduleScope;
         outputHandler = $previousConfig.outputHandler;
-        outputHandlers = $previousConfig.outputHandlers;
+        outputHandlers = $previousConfig.outputHandlers.Clone();
     }
 
     if ($framework) {

--- a/src/private/ExecuteInBuildFileScope.ps1
+++ b/src/private/ExecuteInBuildFileScope.ps1
@@ -43,7 +43,7 @@ function ExecuteInBuildFileScope {
     $currentContext = $psake.context.Peek()
 
     if ($framework -ne $frameworkOldValue) {
-        writecoloredoutput $msgs.warning_deprecated_framework_variable -foregroundcolor Yellow
+        WriteOutput $msgs.warning_deprecated_framework_variable "warning"
         $currentContext.config.framework = $framework
     }
 

--- a/src/private/WriteDocumentation.ps1
+++ b/src/private/WriteDocumentation.ps1
@@ -19,8 +19,8 @@ function WriteDocumentation($showDetailed) {
                     }
 
         if ($showDetailed) {
-            $docs | Sort-Object 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default
+            $docs | Sort-Object 'Name' | format-list -property Name,Alias,Description,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default | WriteOutput
         } else {
-            $docs | Sort-Object 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description
+            $docs | Sort-Object 'Name' | format-table -autoSize -wrap -property Name,Alias,@{Label="Depends On";Expression={$_.DependsOn -join ', '}},Default,Description | WriteOutput
         }
     }

--- a/src/private/WriteOutput.ps1
+++ b/src/private/WriteOutput.ps1
@@ -1,0 +1,19 @@
+function WriteOutput {
+    [CmdLetBinding()]
+    Param (
+        [Parameter(Position=0,ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true)]
+        [object]$Output,
+        [Parameter(Position=1,ValueFromPipelineByPropertyName=$true)]
+        [string]$OutputType = "default"
+    )
+
+    Process {
+        if ($psake.context.peek().config.outputHandler -is [scriptblock]) {
+            & $psake.context.peek().config.outputHandler $Output $OutputType
+        }
+        else {
+            Write-Warning "The psake OutputHandler is invalid. Write-Output will be used."
+            Write-Output $Output
+        }
+    }
+}

--- a/src/private/WriteTaskTimeSummary.ps1
+++ b/src/private/WriteTaskTimeSummary.ps1
@@ -1,9 +1,16 @@
 function WriteTaskTimeSummary($invokePsakeDuration) {
     if ($psake.context.count -gt 0) {
         $currentContext = $psake.context.Peek()
-        WriteOutput ("-" * 70)
-        WriteOutput "Build Time Report"
-        WriteOutput ("-" * 70)
+        if ($currentContext.config.taskNameFormat -is [ScriptBlock]) {
+            & $currentContext.config.taskNameFormat "Build Time Report"
+        } elseif ($currentContext.config.taskNameFormat -ne "Executing {0}") {
+            $currentContext.config.taskNameFormat -f "Build Time Report"
+        } else {
+            WriteOutput ("-" * 70)
+            WriteOutput "Build Time Report"
+            WriteOutput ("-" * 70)
+        }
+
         $list = @()
         while ($currentContext.executedTasks.Count -gt 0) {
             $taskKey = $currentContext.executedTasks.Pop()
@@ -11,17 +18,17 @@ function WriteTaskTimeSummary($invokePsakeDuration) {
             if ($taskKey -eq "default") {
                 continue
             }
-            $list += new-object PSObject -property @{
-                Name = $task.Name;
+            $list += New-Object PSObject -Property @{
+                Name = $task.Name
                 Duration = $task.Duration.ToString("hh\:mm\:ss\.fff")
             }
         }
         [Array]::Reverse($list)
-        $list += new-object PSObject -property @{
-            Name = "Total:";
+        $list += New-Object PSObject -Property @{
+            Name = "Total:"
             Duration = $invokePsakeDuration.ToString("hh\:mm\:ss\.fff")
         }
         # using "out-string | where-object" to filter out the blank line that format-table prepends
-        $list | format-table -autoSize -property Name,Duration | out-string -stream | where-object { $_ } | WriteOutput
+        $list | Format-Table -AutoSize -Property Name, Duration | Out-String -Stream | Where-Object { $_ } | WriteOutput
     }
 }

--- a/src/private/WriteTaskTimeSummary.ps1
+++ b/src/private/WriteTaskTimeSummary.ps1
@@ -1,16 +1,9 @@
 function WriteTaskTimeSummary($invokePsakeDuration) {
     if ($psake.context.count -gt 0) {
         $currentContext = $psake.context.Peek()
-        if ($currentContext.config.taskNameFormat -is [ScriptBlock]) {
-            & $currentContext.config.taskNameFormat "Build Time Report"
-        } elseif ($currentContext.config.taskNameFormat -ne "Executing {0}") {
-            $currentContext.config.taskNameFormat -f "Build Time Report"
-        }
-        else {
-            "-" * 70
-            "Build Time Report"
-            "-" * 70
-        }
+        WriteOutput ("-" * 70)
+        WriteOutput "Build Time Report"
+        WriteOutput ("-" * 70)
         $list = @()
         while ($currentContext.executedTasks.Count -gt 0) {
             $taskKey = $currentContext.executedTasks.Pop()
@@ -29,6 +22,6 @@ function WriteTaskTimeSummary($invokePsakeDuration) {
             Duration = $invokePsakeDuration.ToString("hh\:mm\:ss\.fff")
         }
         # using "out-string | where-object" to filter out the blank line that format-table prepends
-        $list | format-table -autoSize -property Name,Duration | out-string -stream | where-object { $_ }
+        $list | format-table -autoSize -property Name,Duration | out-string -stream | where-object { $_ } | WriteOutput
     }
 }

--- a/src/psake-config.ps1
+++ b/src/psake-config.ps1
@@ -30,7 +30,7 @@ $config.outputHandler = {
 
     Process {
         if ($psake.context.peek().config.outputHandlers.$OutputType -is [scriptblock]) {
-            & $psake.context.peek().config.outputHandlers.$OutputType $Output $OutputType
+            & $psake.context.peek().config.outputHandlers.$OutputType $Output
         }
         elseif ($OutputType -ne "default") {
             Write-Warning "No outputHandler has been defined for $OutputType output. The default outputHandler will be used."

--- a/src/psake-config.ps1
+++ b/src/psake-config.ps1
@@ -16,7 +16,38 @@ Load modules from .\modules folder and from file my_module.psm1
 $config.modules=(".\modules\*.psm1",".\my_module.psm1")
 
 -------------------------------------------------------------------
-Use scriptblock for taskNameFormat
+Use scriptblock for taskNameFormat and outputHandlers
 -------------------------------------------------------------------
 $config.taskNameFormat= { param($taskName) "Executing $taskName at $(get-date)" }
+$config.outputHandler = {
+    [CmdLetBinding()]
+    Param (
+        [Parameter(Position=0)]
+        [object]$Output,
+        [Parameter(Position=1)]
+        [string]$OutputType = "default"
+    )
+
+    Process {
+        if ($psake.context.peek().config.outputHandlers.$OutputType -is [scriptblock]) {
+            & $psake.context.peek().config.outputHandlers.$OutputType $Output $OutputType
+        }
+        elseif ($OutputType -ne "default") {
+            Write-Warning "No outputHandler has been defined for $OutputType output. The default outputHandler will be used."
+            WriteOutput -Output $Output -OutputType "default"
+        }
+        else {
+            Write-Warning "The default outputHandler is invalid. Write-Output will be used."
+            Write-Output $Output
+        }
+    }
+}
+$config.outputHandlers = @{
+    heading         = { Param($output) WriteColoredOutput $output -foregroundcolor Cyan };
+    default         = { Param($output) Write-Output $output };
+    debug           = { Param($output) Write-Debug $output };
+    warning         = { Param($output) WriteColoredOutput $output -foregroundcolor Yellow };
+    error           = { Param($output) WriteColoredOutput $output -foregroundcolor Red };
+    success         = { Param($output) WriteColoredOutput $output -foregroundcolor Green };
+}
 #>

--- a/src/psake.psm1
+++ b/src/psake.psm1
@@ -111,7 +111,7 @@ $psake.config_default = new-object psobject -property @{
 
         Process {
             if ($psake.context.peek().config.outputHandlers.$OutputType -is [scriptblock]) {
-                & $psake.context.peek().config.outputHandlers.$OutputType $Output $OutputType
+                & $psake.context.peek().config.outputHandlers.$OutputType $Output
             }
             elseif ($OutputType -ne "default") {
                 Write-Warning "No outputHandler has been defined for $OutputType output. The default outputHandler will be used."

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -69,7 +69,7 @@ function Invoke-Task {
         $precondition_is_valid = & $task.Precondition
 
         if (!$precondition_is_valid) {
-            WriteColoredOutput ($msgs.precondition_was_false -f $taskName) -foregroundcolor Cyan
+            WriteOutput ($msgs.precondition_was_false -f $taskName) "heading"
         } else {
             if ($taskKey -ne 'default') {
 
@@ -105,7 +105,7 @@ function Invoke-Task {
                                 } else {
                                     $taskHeader = $currentContext.config.taskNameFormat -f $taskName
                                 }
-                                WriteColoredOutput $taskHeader -foregroundcolor Cyan
+                                WriteOutput $taskHeader "heading"
 
                                 & $task.Action
                             } finally {
@@ -131,7 +131,7 @@ function Invoke-Task {
                     } catch {
                         if ($task.ContinueOnError) {
                             "-"*70
-                            WriteColoredOutput ($msgs.continue_on_error -f $taskName,$_) -foregroundcolor Yellow
+                            WriteOutput ($msgs.continue_on_error -f $taskName,$_) "warning"
                             "-"*70
                         }  else {
                             throw $_

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -274,7 +274,7 @@ function Invoke-psake {
                     }
                 }
             } catch {
-                WriteColoredOutput "Parameter '$key' is null" -foregroundcolor Red
+                WriteOutput "Parameter '$key' is null" "error"
                 throw
             }
 
@@ -313,7 +313,7 @@ function Invoke-psake {
             }
 
             $successMsg = $msgs.psake_success -f $buildFile
-            WriteColoredOutput ("$($script:nl)${successMsg}$($script:nl)") -foregroundcolor Green
+            WriteOutput ("$($script:nl)${successMsg}$($script:nl)") "success"
 
             $stopwatch.Stop()
             if (-not $notr) {
@@ -334,7 +334,7 @@ function Invoke-psake {
             throw $_
         } else {
             if (!$psake.run_by_psake_build_tester) {
-                WriteColoredOutput $psake.error_message -foregroundcolor Red
+                WriteOutput $psake.error_message "error"
             }
         }
     } finally {

--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -267,7 +267,7 @@ function Task {
         Assert ($null -ne $taskModule) ($msgs.error_unknown_module -f $FromModule)
         $psakeFilePath = Join-Path -Path $taskModule.ModuleBase -ChildPath 'psakeFile.ps1'
         if (-not $psake.LoadedTaskModules.ContainsKey($psakeFilePath)) {
-            Write-Debug -Message "Loading tasks from task module [$psakeFilePath]"
+            WriteOutput "Loading tasks from task module [$psakeFilePath]" "debug"
             . $psakeFilePath
             $psake.LoadedTaskModules.Add($psakeFilePath, $null)
         }
@@ -319,7 +319,7 @@ function Task {
 
         # Add the task to the context
         Assert (-not $currentContext.tasks.ContainsKey($taskKey)) ($msgs.error_duplicate_task_name -f $taskKey)
-        Write-Debug "Adding task [$taskKey)]"
+        WriteOutput "Adding task [$taskKey)]" "debug"
         $currentContext.tasks[$taskKey] = $newTask
 
         if ($Alias) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There is a new WriteOutput function, which is used throughout the psake code whenever messages need to be logged. The function simply passes the message and message type to an "outputHandler" script block, which can be overridden in psake-config. So you can override exactly how output is handled by overriding that outputHandler script block.

The default outputHandler script block further routes the output according to it's output type (warning, verbose, error, etc) to corresponding script blocks which can also be overridden by psake-config. So you also have the option of overriding how a single type of output is handled.

The default outputHandlers for each message type outputs the message exactly as it would have been prior to this new feature, so it is a non-breaking change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#65 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As described in the issue, if your psake build file uses a different method of logging to psake's internal logging method, it can be difficult to try and handle the messages from each consistently. This change allows you to make psake's internal logging more consistent with your own. You can even have psake's messages routed to your own custom functions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New spec files added to verify the basic functionality, that all of psake's internal logging uses the new WriteOutput function, and that it handles situations where the config items have been overridden with invalid values.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
