### PR TITLE
provide a shorter alias for workingDirectory

### DIFF
--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -62,6 +62,7 @@ function Exec {
 
         [string]$retryTriggerErrorPattern = $null,
 
+        [Alias("wd")]
         [string]$workingDirectory = $null
     )
 


### PR DESCRIPTION
to enable more compact build tasks

<!--- Provide a general summary of your changes in the Title above -->

## Description
adding the alias "wd" for the "workingDirectory" parameter of the Exec command.

## Motivation and Context
It helps putting short commands in a single line and still keep them readable.
Especially usefull when putting many tasks below each other in a tabular form

## How Has This Been Tested?
The change is minimal intrusive, and using a default Powershell feature. Not adding any testable logic.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
