### PR TITLE
(doc) Fix formatting in "Where can I get psake"

### DIFF
--- a/docs/where-can-i-get-psake.md
+++ b/docs/where-can-i-get-psake.md
@@ -1,4 +1,5 @@
-The source code has moved to GitHub: 
+The source code has moved to GitHub:
+
  * https://github.com/psake/psake.git
  * git://github.com/psake/psake.git
 


### PR DESCRIPTION
## Description

This PR modifies doc. It adds a new line after paragraph to help MKDocs understand the following lines form a list.

## Motivation and Context

It fixes a formatting issue on the page https://psake.readthedocs.io/en/latest/where-can-i-get-psake/. Without newline, MKDocs doesn't understand Markdown.

## Screenshots (if appropriate):

Before my changes:

![image](https://user-images.githubusercontent.com/3228886/146890953-f61348ad-d880-4f0d-be88-ddb9c615a12d.png)

After:

<img width="777" alt="Screenshot 2021-12-21 at 09 52 16" src="https://user-images.githubusercontent.com/3228886/146892047-e266eeb5-25c2-49e0-97ca-c47e46f35530.png">


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
