### PR TITLE
Refactor: Tasksetup

### DIFF
--- a/src/public/TaskSetup.ps1
+++ b/src/public/TaskSetup.ps1
@@ -8,18 +8,18 @@ function TaskSetup {
 
         The scriptblock accepts an optional parameter which describes the Task being setup.
 
-        .PARAMETER setup
+        .PARAMETER Setup
         A scriptblock to execute
 
         .EXAMPLE
         A sample build script is shown below:
 
-        Task default -depends Test
+        Task default -Depends Test
 
-        Task Test -depends Compile, Clean {
+        Task Test -Depends Compile, Clean {
         }
 
-        Task Compile -depends Clean {
+        Task Compile -Depends Clean {
         }
 
         Task Clean {
@@ -43,12 +43,12 @@ function TaskSetup {
         .EXAMPLE
         A sample build script showing access to the Task context is shown below:
 
-        Task default -depends Test
+        Task default -Depends Test
 
-        Task Test -depends Compile, Clean {
+        Task Test -Depends Compile, Clean {
         }
 
-        Task Compile -depends Clean {
+        Task Compile -Depends Clean {
         }
 
         Task Clean {
@@ -95,8 +95,8 @@ function TaskSetup {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [scriptblock]$setup
+        [scriptblock]$Setup
     )
 
-    $psake.context.Peek().taskSetupScriptBlock = $setup
+    $psake.context.Peek().taskSetupScriptBlock = $Setup
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help TaskSetup -Full

NAME
    TaskSetup

SYNOPSIS
    Adds a scriptblock that will be executed before each task


SYNTAX
    TaskSetup [-Setup] <ScriptBlock> [<CommonParameters>]


DESCRIPTION
    This function will accept a scriptblock that will be executed before each task in
    the build script.

    The scriptblock accepts an optional parameter which describes the Task being setup.


PARAMETERS
    -Setup <ScriptBlock>
        A scriptblock to execute

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>A sample build script is shown below:

    Task default -Depends Test

    Task Test -Depends Compile, Clean {
    }

    Task Compile -Depends Clean {
    }

    Task Clean {
    }

    TaskSetup {
        "Running 'TaskSetup' for task $context.Peek().currentTaskName"
    }

    The script above produces the following output:

    Running 'TaskSetup' for task Clean
    Executing task, Clean...
    Running 'TaskSetup' for task Compile
    Executing task, Compile...
    Running 'TaskSetup' for task Test
    Executing task, Test...

    Build Succeeded




    -------------------------- EXAMPLE 2 --------------------------

    PS C:\>A sample build script showing access to the Task context is shown below:

    Task default -Depends Test

    Task Test -Depends Compile, Clean {
    }

    Task Compile -Depends Clean {
    }

    Task Clean {
    }

    TaskSetup {
        param($task)

        "Running 'TaskSetup' for task $($task.Name)"
    }

    The script above produces the following output:

    Running 'TaskSetup' for task Clean
    Executing task, Clean...
    Running 'TaskSetup' for task Compile
    Executing task, Compile...
    Running 'TaskSetup' for task Test
    Executing task, Test...

    Build Succeeded





RELATED LINKS
    Assert
    Exec
    FormatTaskName
    Framework
    Get-PSakeScriptTasks
    Include
    Invoke-psake
    Properties
    Task
    TaskTearDown
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
