### PR TITLE
Refactor: Assert

### DIFF
--- a/src/public/Assert.ps1
+++ b/src/public/Assert.ps1
@@ -9,7 +9,7 @@ function Assert {
         .PARAMETER ConditionToCheck
         The boolean condition to evaluate
 
-        .PARAMETER failureMessage
+        .PARAMETER FailureMessage
         The error message used for the exception if the ConditionToCheck parameter is false
 
         .EXAMPLE
@@ -62,10 +62,10 @@ function Assert {
         $ConditionToCheck,
 
         [Parameter(Mandatory = $true)]
-        [string]$failureMessage
+        [string]$FailureMessage
     )
 
     if (-not $ConditionToCheck) {
-        throw ('Assert: {0}' -f $failureMessage)
+        throw ('Assert: {0}' -f $FailureMessage)
     }
 }

--- a/src/public/Assert.ps1
+++ b/src/public/Assert.ps1
@@ -6,11 +6,11 @@ function Assert {
         .DESCRIPTION
         This is a helper function that makes the code less noisy by eliminating many of the "if" statements that are normally required to verify assumptions in the code.
 
-        .PARAMETER conditionToCheck
+        .PARAMETER ConditionToCheck
         The boolean condition to evaluate
 
         .PARAMETER failureMessage
-        The error message used for the exception if the conditionToCheck parameter is false
+        The error message used for the exception if the ConditionToCheck parameter is false
 
         .EXAMPLE
         C:\PS>Assert $false "This always throws an exception"
@@ -24,7 +24,7 @@ function Assert {
 
         Note:
         It might be necessary to wrap the condition with paranthesis to force PS to evaluate the condition
-        so that a boolean value is calculated and passed into the 'conditionToCheck' parameter.
+        so that a boolean value is calculated and passed into the 'ConditionToCheck' parameter.
 
         Example:
             Assert 1 -eq 2 "1 doesn't equal 2"
@@ -59,13 +59,13 @@ function Assert {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        $conditionToCheck,
+        $ConditionToCheck,
 
         [Parameter(Mandatory = $true)]
         [string]$failureMessage
     )
 
-    if (-not $conditionToCheck) {
+    if (-not $ConditionToCheck) {
         throw ('Assert: {0}' -f $failureMessage)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help Assert -Full

NAME
    Assert

SYNOPSIS
    Helper function for "Design by Contract" assertion checking.


SYNTAX
    Assert [-ConditionToCheck] <Object> [-FailureMessage] <String> [<CommonParameters>]


DESCRIPTION
    This is a helper function that makes the code less noisy by eliminating many of the
    "if" statements that are normally required to verify assumptions in the code.


PARAMETERS
    -ConditionToCheck <Object>
        The boolean condition to evaluate

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    -FailureMessage <String>
        The error message used for the exception if the ConditionToCheck parameter is
        false

        Required?                    true
        Position?                    2
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    C:\PS>Assert $false "This always throws an exception"

    Example of an assertion that will always fail.




    -------------------------- EXAMPLE 2 --------------------------

    C:\PS>Assert ( ($i % 2) -eq 0 ) "$i is not an even number"

    This exmaple may throw an exception if $i is not an even number

    Note:
    It might be necessary to wrap the condition with paranthesis to force PS to evaluate
    the condition
    so that a boolean value is calculated and passed into the 'ConditionToCheck'
    parameter.

    Example:
        Assert 1 -eq 2 "1 doesn't equal 2"

    PS will pass 1 into the condtionToCheck variable and PS will look for a parameter
    called "eq" and
    throw an exception with the following message "A parameter cannot be found that
    matches parameter name 'eq'"

    The solution is to wrap the condition in () so that PS will evaluate it first.

    Assert (1 -eq 2) "1 doesn't equal 2"





RELATED LINKS
    Exec
    FormatTaskName
    Framework
    Get-PSakeScriptTasks
    Include
    Invoke-psake
    Properties
    Task
    TaskSetup
    TaskTearDown
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
