### PR TITLE
Refactor: BuildTearDown

### DIFF
--- a/src/public/BuildTearDown.ps1
+++ b/src/public/BuildTearDown.ps1
@@ -4,14 +4,14 @@ function BuildTearDown {
         Adds a scriptblock that will be executed once at the end of the build
         .DESCRIPTION
         This function will accept a scriptblock that will be executed once at the end of the build, regardless of success or failure
-        .PARAMETER setup
+        .PARAMETER Setup
         A scriptblock to execute
         .EXAMPLE
         A sample build script is shown below:
-        Task default -depends Test
-        Task Test -depends Compile, Clean {
+        Task default -Depends Test
+        Task Test -Depends Compile, Clean {
         }
-        Task Compile -depends Clean {
+        Task Compile -Depends Clean {
         }
         Task Clean {
         }
@@ -26,11 +26,11 @@ function BuildTearDown {
         Build Succeeded
         .EXAMPLE
         A failing build script is shown below:
-        Task default -depends Test
-        Task Test -depends Compile, Clean {
+        Task default -Depends Test
+        Task Test -Depends Compile, Clean {
             throw "forced error"
         }
-        Task Compile -depends Clean {
+        Task Compile -Depends Clean {
         }
         Task Clean {
         }
@@ -68,8 +68,8 @@ function BuildTearDown {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [scriptblock]$setup
+        [scriptblock]$Setup
     )
 
-    $psake.context.Peek().buildTearDownScriptBlock = $setup
+    $psake.context.Peek().buildTearDownScriptBlock = $Setup
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help BuildTearDown -Full

NAME
    BuildTearDown

SYNOPSIS
    Adds a scriptblock that will be executed once at the end of the build


SYNTAX
    BuildTearDown [-Setup] <ScriptBlock> [<CommonParameters>]


DESCRIPTION
    This function will accept a scriptblock that will be executed once at the end of the
    build, regardless of success or failure


PARAMETERS
    -Setup <ScriptBlock>
        A scriptblock to execute

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>A sample build script is shown below:

    Task default -Depends Test
    Task Test -Depends Compile, Clean {
    }
    Task Compile -Depends Clean {
    }
    Task Clean {
    }
    BuildTearDown {
        "Running 'BuildTearDown'"
    }
    The script above produces the following output:
    Executing task, Clean...
    Executing task, Compile...
    Executing task, Test...
    Running 'BuildTearDown'
    Build Succeeded




    -------------------------- EXAMPLE 2 --------------------------

    PS C:\>A failing build script is shown below:

    Task default -Depends Test
    Task Test -Depends Compile, Clean {
        throw "forced error"
    }
    Task Compile -Depends Clean {
    }
    Task Clean {
    }
    BuildTearDown {
        "Running 'BuildTearDown'"
    }
    The script above produces the following output:
    Executing task, Clean...
    Executing task, Compile...
    Executing task, Test...
    Running 'BuildTearDown'
    forced error
    At line:x char:x ...





RELATED LINKS
    Assert
    Exec
    FormatTaskName
    Framework
    Invoke-psake
    Properties
    Task
    BuildSetup
    TaskSetup
    TaskTearDown
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
