### PR TITLE
Refactor: Exec

### DIFF
--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -8,7 +8,7 @@ function Exec {
         If an error is detected then an exception is thrown.
         This function allows you to run command-line programs without having to explicitly check fthe $lastexitcode variable.
 
-        .PARAMETER cmd
+        .PARAMETER Cmd
         The scriptblock to execute. This scriptblock will typically contain the command-line invocation.
 
         .PARAMETER errorMessage
@@ -54,9 +54,9 @@ function Exec {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [scriptblock]$cmd,
+        [scriptblock]$Cmd,
 
-        [string]$errorMessage = ($msgs.error_bad_command -f $cmd),
+        [string]$errorMessage = ($msgs.error_bad_command -f $Cmd),
 
         [int]$maxRetries = 0,
 
@@ -76,7 +76,7 @@ function Exec {
             }
 
             $global:lastexitcode = 0
-            & $cmd
+            & $Cmd
             if ($global:lastexitcode -ne 0) {
                 throw "Exec: $errorMessage"
             }

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -14,12 +14,12 @@ function Exec {
         .PARAMETER ErrorMessage
         The error message to display if the external command returned a non-zero exit code.
 
-        .PARAMETER maxRetries
+        .PARAMETER MaxRetries
         The maximum number of times to retry the command before failing.
 
         .PARAMETER retryTriggerErrorPattern
         If the external command raises an exception, match the exception against this regex to determine if the command can be retried.
-        If a match is found, the command will be retried provided [maxRetries] has not been reached.
+        If a match is found, the command will be retried provided [MaxRetries] has not been reached.
 
         .PARAMETER workingDirectory
         The working directory to set before running the external command.
@@ -58,7 +58,7 @@ function Exec {
 
         [string]$ErrorMessage = ($msgs.error_bad_command -f $Cmd),
 
-        [int]$maxRetries = 0,
+        [int]$MaxRetries = 0,
 
         [string]$retryTriggerErrorPattern = $null,
 
@@ -83,7 +83,7 @@ function Exec {
             break
         }
         catch [Exception] {
-            if ($tryCount -gt $maxRetries) {
+            if ($tryCount -gt $MaxRetries) {
                 throw $_
             }
 

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -21,7 +21,7 @@ function Exec {
         If the external command raises an exception, match the exception against this regex to determine if the command can be retried.
         If a match is found, the command will be retried provided [MaxRetries] has not been reached.
 
-        .PARAMETER workingDirectory
+        .PARAMETER WorkingDirectory
         The working directory to set before running the external command.
 
         .EXAMPLE
@@ -63,7 +63,7 @@ function Exec {
         [string]$RetryTriggerErrorPattern = $null,
 
         [Alias("wd")]
-        [string]$workingDirectory = $null
+        [string]$WorkingDirectory = $null
     )
 
     $tryCount = 1
@@ -71,8 +71,8 @@ function Exec {
     do {
         try {
 
-            if ($workingDirectory) {
-                Push-Location -Path $workingDirectory
+            if ($WorkingDirectory) {
+                Push-Location -Path $WorkingDirectory
             }
 
             $global:lastexitcode = 0
@@ -102,7 +102,7 @@ function Exec {
             [System.Threading.Thread]::Sleep([System.TimeSpan]::FromSeconds(1))
         }
         finally {
-            if ($workingDirectory) {
+            if ($WorkingDirectory) {
                 Pop-Location
             }
         }

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -11,7 +11,7 @@ function Exec {
         .PARAMETER Cmd
         The scriptblock to execute. This scriptblock will typically contain the command-line invocation.
 
-        .PARAMETER errorMessage
+        .PARAMETER ErrorMessage
         The error message to display if the external command returned a non-zero exit code.
 
         .PARAMETER maxRetries
@@ -56,7 +56,7 @@ function Exec {
         [Parameter(Mandatory = $true)]
         [scriptblock]$Cmd,
 
-        [string]$errorMessage = ($msgs.error_bad_command -f $Cmd),
+        [string]$ErrorMessage = ($msgs.error_bad_command -f $Cmd),
 
         [int]$maxRetries = 0,
 
@@ -78,7 +78,7 @@ function Exec {
             $global:lastexitcode = 0
             & $Cmd
             if ($global:lastexitcode -ne 0) {
-                throw "Exec: $errorMessage"
+                throw "Exec: $ErrorMessage"
             }
             break
         }

--- a/src/public/Exec.ps1
+++ b/src/public/Exec.ps1
@@ -17,7 +17,7 @@ function Exec {
         .PARAMETER MaxRetries
         The maximum number of times to retry the command before failing.
 
-        .PARAMETER retryTriggerErrorPattern
+        .PARAMETER RetryTriggerErrorPattern
         If the external command raises an exception, match the exception against this regex to determine if the command can be retried.
         If a match is found, the command will be retried provided [MaxRetries] has not been reached.
 
@@ -60,7 +60,7 @@ function Exec {
 
         [int]$MaxRetries = 0,
 
-        [string]$retryTriggerErrorPattern = $null,
+        [string]$RetryTriggerErrorPattern = $null,
 
         [Alias("wd")]
         [string]$workingDirectory = $null
@@ -87,8 +87,8 @@ function Exec {
                 throw $_
             }
 
-            if ($retryTriggerErrorPattern -ne $null) {
-                $isMatch = [regex]::IsMatch($_.Exception.Message, $retryTriggerErrorPattern)
+            if ($RetryTriggerErrorPattern -ne $null) {
+                $isMatch = [regex]::IsMatch($_.Exception.Message, $RetryTriggerErrorPattern)
 
                 if ($isMatch -eq $false) {
                     throw $_


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help Exec -Full

NAME
    Exec

SYNOPSIS
    Helper function for executing command-line programs.


SYNTAX
    Exec [-Cmd] <ScriptBlock> [[-ErrorMessage] <String>] [[-MaxRetries] <Int32>]
    [[-RetryTriggerErrorPattern] <String>] [[-WorkingDirectory] <String>]
    [<CommonParameters>]


DESCRIPTION
    This is a helper function that runs a scriptblock and checks the PS variable
    $lastexitcode to see if an error occcured.
    If an error is detected then an exception is thrown.
    This function allows you to run command-line programs without having to explicitly
    check fthe $lastexitcode variable.


PARAMETERS
    -Cmd <ScriptBlock>
        The scriptblock to execute. This scriptblock will typically contain the
        command-line invocation.

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    -ErrorMessage <String>
        The error message to display if the external command returned a non-zero exit
        code.

        Required?                    false
        Position?                    2
        Default value                ($msgs.error_bad_command -f $Cmd)
        Accept pipeline input?       false
        Accept wildcard characters?  false

    -MaxRetries <Int32>
        The maximum number of times to retry the command before failing.

        Required?                    false
        Position?                    3
        Default value                0
        Accept pipeline input?       false
        Accept wildcard characters?  false

    -RetryTriggerErrorPattern <String>
        If the external command raises an exception, match the exception against this
        regex to determine if the command can be retried.
        If a match is found, the command will be retried provided [MaxRetries] has not
        been reached.

        Required?                    false
        Position?                    4
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    -WorkingDirectory <String>
        The working directory to set before running the external command.

        Required?                    false
        Position?                    5
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>exec { svn info $repository_trunk } "Error executing SVN. Please verify SVN
    command-line client is installed"

    This example calls the svn command-line client.





RELATED LINKS
    Assert
    FormatTaskName
    Framework
    Get-PSakeScriptTasks
    Include
    Invoke-psake
    Properties
    Task
    TaskSetup
    TaskTearDown
    Properties
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
