### PR TITLE
Refactor: FormatTaskName

### DIFF
--- a/src/public/FormatTaskName.ps1
+++ b/src/public/FormatTaskName.ps1
@@ -6,7 +6,7 @@ function FormatTaskName {
         .DESCRIPTION
         This function takes either a string which represents a format string (formats using the -f format operator see "help about_operators") or it can accept a script block that has a single parameter that is the name of the task that will be executed.
 
-        .PARAMETER format
+        .PARAMETER Format
         A format string or a scriptblock to execute
 
         .EXAMPLE
@@ -88,8 +88,8 @@ function FormatTaskName {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        $format
+        $Format
     )
 
-    $psake.context.Peek().config.taskNameFormat = $format
+    $psake.context.Peek().config.taskNameFormat = $Format
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help FormatTaskName -Full

NAME
    FormatTaskName

SYNOPSIS
    This function allows you to change how psake renders the task name during a build.


SYNTAX
    FormatTaskName [-Format] <Object> [<CommonParameters>]


DESCRIPTION
    This function takes either a string which represents a format string (formats using
    the -f format operator see "help about_operators") or it can accept a script block
    that has a single parameter that is the name of the task that will be executed.


PARAMETERS
    -Format <Object>
        A format string or a scriptblock to execute

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>A sample build script that uses a format string is shown below:

    Task default -depends TaskA, TaskB, TaskC

    FormatTaskName "-------- {0} --------"

    Task TaskA {
    "TaskA is executing"
    }

    Task TaskB {
    "TaskB is executing"
    }

    Task TaskC {
    "TaskC is executing"

    -----------
    The script above produces the following output:

    -------- TaskA --------
    TaskA is executing
    -------- TaskB --------
    TaskB is executing
    -------- TaskC --------
    TaskC is executing

    Build Succeeded!




    -------------------------- EXAMPLE 2 --------------------------

    PS C:\>A sample build script that uses a ScriptBlock is shown below:

    Task default -depends TaskA, TaskB, TaskC

    FormatTaskName {
        param($taskName)
        write-host "Executing Task: $taskName" -foregroundcolor blue
    }

    Task TaskA {
    "TaskA is executing"
    }

    Task TaskB {
    "TaskB is executing"
    }

    Task TaskC {
    "TaskC is executing"
    }

    -----------
    The above example uses the scriptblock parameter to the FormatTaskName function to
    render each task name in the color blue.

    Note: the $taskName parameter is arbitrary, it could be named anything.





RELATED LINKS
    Assert
    Exec
    Framework
    Get-PSakeScriptTasks
    Include
    Invoke-psake
    Properties
    Task
    TaskSetup
    TaskTearDown
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
