### PR TITLE
Refactor: Framework

### DIFF
--- a/src/public/Framework.ps1
+++ b/src/public/Framework.ps1
@@ -8,7 +8,7 @@ function Framework {
     Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x64', '3.5', '3.5x86', '3.5x64', '4.0', '4.0x86', '4.0x64', '4.5', '4.5x86', '4.5x64', '4.5.1', '4.5.1x86', '4.5.1x64'.
     Default is '3.5*', where x86 or x64 will be detected based on the bitness of the PowerShell process.
 
-    .PARAMETER framework
+    .PARAMETER Framework
     Version of the .NET framework to use during build.
 
     .EXAMPLE
@@ -46,10 +46,10 @@ function Framework {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory = $true)]
-        [string]$framework
+        [string]$Framework
     )
 
-    $psake.context.Peek().config.framework = $framework
+    $psake.context.Peek().config.framework = $Framework
 
     ConfigureBuildEnvironment
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help Framework -Full

NAME
    Framework

SYNOPSIS
    Sets the version of the .NET framework you want to use during build.


SYNTAX
    Framework [-Framework] <String> [<CommonParameters>]


DESCRIPTION
    This function will accept a string containing version of the .NET framework to use
    during build.
    Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86', '3.0x64',
    '3.5', '3.5x86', '3.5x64', '4.0', '4.0x86', '4.0x64', '4.5', '4.5x86', '4.5x64',
    '4.5.1', '4.5.1x86', '4.5.1x64'.
    Default is '3.5*', where x86 or x64 will be detected based on the bitness of the
    PowerShell process.


PARAMETERS
    -Framework <String>
        Version of the .NET framework to use during build.

        Required?                    true
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>Framework "4.0"

    Task default -depends Compile

    Task Compile -depends Clean {
        msbuild /version
    }

    -----------
    The script above will output detailed version of msbuid v4





RELATED LINKS
    Assert
    Exec
    FormatTaskName
    Get-PSakeScriptTasks
    Include
    Invoke-psake
    Properties
    Task
    TaskSetup
    TaskTearDown
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
