### PR TITLE
Refactor: Get-PSakeScriptTasks

### DIFF
--- a/src/public/Get-PSakeScriptTasks.ps1
+++ b/src/public/Get-PSakeScriptTasks.ps1
@@ -6,11 +6,11 @@ function Get-PSakeScriptTasks {
     .DESCRIPTION
     Returns meta data about all the tasks defined in the provided psake script.
 
-    .PARAMETER buildFile
+    .PARAMETER BuildFile
     The path to the psake build script to read the tasks from.
 
     .EXAMPLE
-    PS C:\>Get-PSakeScriptTasks -buildFile '.\build.ps1'
+    PS C:\>Get-PSakeScriptTasks -BuildFile '.\build.ps1'
 
     DependsOn        Alias Name    Description
     ---------        ----- ----    -----------
@@ -27,15 +27,15 @@ function Get-PSakeScriptTasks {
     [System.Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
     [CmdletBinding()]
     param(
-        [string]$buildFile
+        [string]$BuildFile
     )
 
-    if (-not $buildFile) {
-        $buildFile = $psake.config_default.buildFileName
+    if (-not $BuildFile) {
+        $BuildFile = $psake.config_default.BuildFileName
     }
 
     try {
-        ExecuteInBuildFileScope $buildFile $MyInvocation.MyCommand.Module {
+        ExecuteInBuildFileScope $BuildFile $MyInvocation.MyCommand.Module {
             param($currentContext, $module)
             return GetTasksFromContext $currentContext
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Convert parameter names into pascal

## Description
<!--- Describe your changes in detail -->
Convert parameter names into pascal
## Related Issue
#308 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
ps>Get-Help Get-PSakeScriptTasks -Full

NAME
    Get-PSakeScriptTasks

SYNOPSIS
    Returns meta data about all the tasks defined in the provided psake script.


SYNTAX
    Get-PSakeScriptTasks [[-BuildFile] <String>] [<CommonParameters>]


DESCRIPTION
    Returns meta data about all the tasks defined in the provided psake script.


PARAMETERS
    -BuildFile <String>
        The path to the psake build script to read the tasks from.

        Required?                    false
        Position?                    1
        Default value
        Accept pipeline input?       false
        Accept wildcard characters?  false

    <CommonParameters>
        This cmdlet supports the common parameters: Verbose, Debug,
        ErrorAction, ErrorVariable, WarningAction, WarningVariable,
        OutBuffer, PipelineVariable, and OutVariable. For more information, see
        about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).

INPUTS

OUTPUTS

    -------------------------- EXAMPLE 1 --------------------------

    PS C:\>Get-PSakeScriptTasks -BuildFile '.\build.ps1'

    DependsOn        Alias Name    Description
    ---------        ----- ----    -----------
    {}                     Compile
    {}                     Clean
    {Test}                 Default
    {Clean, Compile}       Test

    Gets the psake tasks contained in the 'build.ps1' file.





RELATED LINKS
    Invoke-psake
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
