### PR TITLE
Fix CI Testing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 jobs:
   test:
     name: Run Tests

--- a/requirements.psd1
+++ b/requirements.psd1
@@ -4,7 +4,7 @@
         Repository = 'PSGallery'
     }
     BuildHelpers     = '2.0.16'
-    Pester           = '5.1.1'
+    Pester           = '5.6.1'
     PlatyPS          = '0.14.1'
     PSScriptAnalyzer = '1.19.1'
 }

--- a/tests/Help.tests.ps1
+++ b/tests/Help.tests.ps1
@@ -1,7 +1,7 @@
 # Taken with love from @juneb_get_help (https://raw.githubusercontent.com/juneb/PesterTDD/master/Module.Help.Tests.ps1)
 
 BeforeDiscovery {
-    function script:FilterOutCommonParams {
+    function global:FilterOutCommonParams {
         param ($Params)
         $commonParams = [System.Management.Automation.PSCmdlet]::OptionalCommonParameters +
             [System.Management.Automation.PSCmdlet]::CommonParameters
@@ -37,7 +37,7 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         # Get command help, parameters, and links
         $command               = $_
         $commandHelp           = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters     = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters     = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames = $commandParameters.Name
         # $helpLinks             = $commandHelp.relatedLinks.navigationLink.uri
     }
@@ -47,9 +47,9 @@ Describe "Test help for <_.Name>" -ForEach $commands {
         $command                = $_
         $commandName            = $_.Name
         $commandHelp            = Get-Help $command.Name -ErrorAction SilentlyContinue
-        $commandParameters      = script:FilterOutCommonParams -Params $command.ParameterSets.Parameters
+        $commandParameters      = global:FilterOutCommonParams -Params $command.ParameterSets.Parameters
         $commandParameterNames  = $commandParameters.Name
-        $helpParameters         = script:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
+        $helpParameters         = global:FilterOutCommonParams -Params $commandHelp.Parameters.Parameter
         $helpParameterNames     = $helpParameters.Name
     }
 


### PR DESCRIPTION
## Description
Pester is pre-installed on Windows GitHub runner and is using a newer version. This should fix the tests.

## Related Issue

## Motivation and Context
The Windows GitHub tests fail because a newer version is required.

## How Has This Been Tested?
Will be tested via CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
