### PR TITLE
(doc) Fix minor typo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Readme
 
-This folder user to contain Command References and examples on how to use psake.
+This folder used to contain Command References and examples on how to use psake.
 All of that has been published to [psake.dev](https://psake.dev) and organized
 so it's easier to understand.
 


### PR DESCRIPTION
Happened to notice this when reviewing docs associated with the latest release of psake.