### PR TITLE
Run CI only when src changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
   pull_request:
+    paths:
+      - 'src/**'
   workflow_dispatch:
 jobs:
   test:


### PR DESCRIPTION
This changes the CI workflow to only run when files under the src directory change.