### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/psake/psake/security/code-scanning/4](https://github.com/psake/psake/security/code-scanning/4)

To fix the problem, add a `permissions` key to either the workflow root or to each job section, specifying only the minimum required privileges for the jobs. The single best solution is to add a root-level `permissions` block just below the workflow `name:` and `on:`, setting `contents: read`, which gives read-only access to repository contents, sufficient for checkout and likely any other steps in these jobs (unless a specific job requires more, which can be separately handled). Edit `.github/workflows/publish.yml` and insert:

```yaml
permissions:
  contents: read
```

just after the `name:` and before `on:` or after `on:` section. No imports or other definitions are required for this YAML change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
