### PR TITLE
Add Annotated to OutputFormat ValidateSet and PSAKE_OUTPUT_FORMAT env-var fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- `Write-BuildAnnotation` now escapes all property values (file,
+  title) per the GitHub Actions `escapeProperty` spec — colons,
+  commas, newlines, and carriage returns are percent-encoded in
+  all property fields, not just title
 - `Exec` now captures and displays full command output (stdout
   and stderr) on failure — many CLI tools like Chocolatey write
   errors to stdout, which was previously invisible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Local file-based caching: tasks with `Inputs`/`Outputs` (glob patterns or scriptblocks) are content-addressed cached in `.psake/cache/`; unchanged tasks are skipped
 - `-NoCache` parameter on `Invoke-psake`: bypass caching for a single run
 - Structured output: `Invoke-psake` returns a `PsakeBuildResult` with per-task `PsakeTaskResult` (status, duration, cached flag, error record)
-- `-OutputFormat JSON|GitHubActions` parameter on `Invoke-psake` for CI integration; GitHubActions emits `::error::`, `::warning::`, `::debug::` workflow annotations
+- `-OutputFormat JSON|GitHubActions|Annotated` parameter on `Invoke-psake` for CI and editor integration; GitHubActions emits `::error::`, `::warning::`, `::debug::` workflow annotations; Annotated emits colored human output **plus** positioned `::error file=<path>,line=<n>,col=<n>,title=<task>::<message>` annotation lines for VS Code problem matcher integration
+- `PSAKE_OUTPUT_FORMAT` environment variable fallback: when `-OutputFormat` is not passed explicitly, psake reads this env var; allows wrapper scripts (e.g. `build.ps1`) to inherit the format from the VS Code extension without source changes
 - `-Quiet` parameter on `Invoke-psake`: suppress all console output while still returning structured results
 - `Get-PsakeBuildPlan` function: testability API to compile a build file and inspect the plan without executing
 - `Test-PsakeTask` function: testability API to execute a single task in isolation without triggering dependencies

--- a/specs/annotated_output_format_failing_task_should_fail.ps1
+++ b/specs/annotated_output_format_failing_task_should_fail.ps1
@@ -1,3 +1,5 @@
-task default {
+task default -depends FailingTask
+
+task FailingTask {
     throw "Test error from annotated output format spec"
 }

--- a/specs/annotated_output_format_failing_task_should_fail.ps1
+++ b/specs/annotated_output_format_failing_task_should_fail.ps1
@@ -1,0 +1,3 @@
+task default {
+    throw "Test error from annotated output format spec"
+}

--- a/src/enums/OutputTypes.ps1
+++ b/src/enums/OutputTypes.ps1
@@ -12,4 +12,5 @@ enum OutputFormat {
     JSON
     Quiet
     GitHubActions
+    Annotated
 }

--- a/src/private/Invoke-BuildPlan.ps1
+++ b/src/private/Invoke-BuildPlan.ps1
@@ -199,16 +199,22 @@ function Invoke-BuildPlan {
                         # This fires for all task failure paths (absorbed or rethrown).
                         $annotationRecord = $_
                         if ($annotationRecord.InvocationInfo) {
-                            Write-BuildAnnotation -Severity 'error' `
-                                -File    $annotationRecord.InvocationInfo.ScriptName `
-                                -Line    $annotationRecord.InvocationInfo.ScriptLineNumber `
-                                -Column  $annotationRecord.InvocationInfo.OffsetInLine `
-                                -Title   $task.Name `
-                                -Message $annotationRecord.Exception.Message
+                            $writeBuildAnnotationSplat = @{
+                                Severity = 'error'
+                                File     = $annotationRecord.InvocationInfo.ScriptName
+                                Line     = $annotationRecord.InvocationInfo.ScriptLineNumber
+                                Column   = $annotationRecord.InvocationInfo.OffsetInLine
+                                Title    = $task.Name
+                                Message  = $annotationRecord.Exception.Message
+                            }
+                            Write-BuildAnnotation @writeBuildAnnotationSplat
                         } else {
-                            Write-BuildAnnotation -Severity 'error' `
-                                -Title   $task.Name `
-                                -Message $annotationRecord.Exception.Message
+                            $writeBuildAnnotationSplat = @{
+                                Severity = 'error'
+                                Title    = $task.Name
+                                Message  = $annotationRecord.Exception.Message
+                            }
+                            Write-BuildAnnotation @writeBuildAnnotationSplat
                         }
 
                         if ($task.ContinueOnError) {

--- a/src/private/Invoke-BuildPlan.ps1
+++ b/src/private/Invoke-BuildPlan.ps1
@@ -194,6 +194,23 @@ function Invoke-BuildPlan {
                             $null = & $CurrentContext.taskTearDownScriptBlock $task
                         }
                     } catch {
+                        # Emit a positioned annotation so VS Code's problem matcher can
+                        # populate the Problems panel with a clickable file:line entry.
+                        # This fires for all task failure paths (absorbed or rethrown).
+                        $annotationRecord = $_
+                        if ($annotationRecord.InvocationInfo) {
+                            Write-BuildAnnotation -Severity 'error' `
+                                -File    $annotationRecord.InvocationInfo.ScriptName `
+                                -Line    $annotationRecord.InvocationInfo.ScriptLineNumber `
+                                -Column  $annotationRecord.InvocationInfo.OffsetInLine `
+                                -Title   $task.Name `
+                                -Message $annotationRecord.Exception.Message
+                        } else {
+                            Write-BuildAnnotation -Severity 'error' `
+                                -Title   $task.Name `
+                                -Message $annotationRecord.Exception.Message
+                        }
+
                         if ($task.ContinueOnError) {
                             # Failure absorbed — do not propagate to this task's own dependents
                             Write-BuildMessage ("-" * 70)

--- a/src/private/Write-BuildAnnotation.ps1
+++ b/src/private/Write-BuildAnnotation.ps1
@@ -13,12 +13,19 @@ function Write-BuildAnnotation {
     Fields are omitted when empty or zero. Field ordering is fixed (file, line,
     col, title) because the VS Code problem matcher regex depends on it.
 
-    Escaping follows the GitHub Actions specification:
+    Escaping follows the GitHub Actions workflow command specification:
+
+    Property values (file, title, etc.):
         %  -> %25  (encoded first to avoid double-encoding)
         \r -> %0D
         \n -> %0A
-        ,  -> %2C  (title only)
-        :  -> %3A  (title only)
+        :  -> %3A
+        ,  -> %2C
+
+    Message (data) value:
+        %  -> %25
+        \r -> %0D
+        \n -> %0A
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "PSAvoidUsingWriteHost",
@@ -44,15 +51,15 @@ function Write-BuildAnnotation {
         return
     }
 
-    # Escape per GitHub Actions spec — percent first to avoid double-encoding
+    # Escape per GitHub Actions spec — percent first to avoid double-encoding.
+    # Property values need all five escapes; the message (data) needs only three.
     $escapedMessage = $Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
-    $escapedTitle   = $Title   -replace '%', '%25' -replace ',', '%2C' -replace ':', '%3A'
 
     # Build optional fields in the fixed order required by the VS Code regex:
     # file, line, col, title
     $fields = [System.Collections.Generic.List[string]]::new()
     if (-not [string]::IsNullOrEmpty($File)) {
-        $escapedFile = $File -replace '%', '%25'
+        $escapedFile = $File -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
         $fields.Add("file=$escapedFile")
     }
     if ($Line -gt 0) {
@@ -62,6 +69,7 @@ function Write-BuildAnnotation {
         $fields.Add("col=$Column")
     }
     if (-not [string]::IsNullOrEmpty($Title)) {
+        $escapedTitle = $Title -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
         $fields.Add("title=$escapedTitle")
     }
 

--- a/src/private/Write-BuildAnnotation.ps1
+++ b/src/private/Write-BuildAnnotation.ps1
@@ -1,0 +1,78 @@
+function Write-BuildAnnotation {
+    <#
+    .SYNOPSIS
+    Emits a GitHub Actions / VS Code problem-matcher annotation line.
+
+    .DESCRIPTION
+    Writes a single-line annotation in the GitHub Actions workflow command format:
+        ::severity file=<path>,line=<n>,col=<n>,title=<task>::<message>
+
+    Only emits output when the current output format is Annotated or GitHubActions.
+    In all other formats this function is a no-op.
+
+    Fields are omitted when empty or zero. Field ordering is fixed (file, line,
+    col, title) because the VS Code problem matcher regex depends on it.
+
+    Escaping follows the GitHub Actions specification:
+        %  -> %25  (encoded first to avoid double-encoding)
+        \r -> %0D
+        \n -> %0A
+        ,  -> %2C  (title only)
+        :  -> %3A  (title only)
+    #>
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "PSAvoidUsingWriteHost",
+        "",
+        Justification = "Annotation lines must be plain text with no ANSI color codes. Write-Host without -ForegroundColor satisfies this requirement."
+    )]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('error', 'warning')]
+        [string] $Severity,
+
+        [string] $File,
+        [int]    $Line = 0,
+        [int]    $Column = 0,
+        [string] $Title,
+        [Parameter(Mandatory)]
+        [string] $Message
+    )
+
+    # No-op for any format that is not Annotated or GitHubActions
+    if ($script:CurrentOutputFormat -ne 'Annotated' -and $script:CurrentOutputFormat -ne 'GitHubActions') {
+        return
+    }
+
+    # Escape per GitHub Actions spec — percent first to avoid double-encoding
+    $escapedMessage = $Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+    $escapedTitle   = $Title   -replace '%', '%25' -replace ',', '%2C' -replace ':', '%3A'
+
+    # Build optional fields in the fixed order required by the VS Code regex:
+    # file, line, col, title
+    $fields = [System.Collections.Generic.List[string]]::new()
+    if (-not [string]::IsNullOrEmpty($File)) {
+        $escapedFile = $File -replace '%', '%25'
+        $fields.Add("file=$escapedFile")
+    }
+    if ($Line -gt 0) {
+        $fields.Add("line=$Line")
+    }
+    if ($Column -gt 0) {
+        $fields.Add("col=$Column")
+    }
+    if (-not [string]::IsNullOrEmpty($Title)) {
+        $fields.Add("title=$escapedTitle")
+    }
+
+    if ($fields.Count -gt 0) {
+        $annotation = "::$Severity $($fields -join ',')::$escapedMessage"
+    } else {
+        $annotation = "::$Severity::$escapedMessage"
+    }
+
+    # Write-Host without -ForegroundColor ensures no ANSI escape codes.
+    # $env:NO_COLOR is intentionally NOT honoured — annotations must always be
+    # plain text regardless of colour preferences.
+    Write-Host $annotation
+}

--- a/src/private/Write-BuildMessage.ps1
+++ b/src/private/Write-BuildMessage.ps1
@@ -5,8 +5,10 @@ function Write-BuildMessage {
 
     .DESCRIPTION
     Replaces the old Write-PsakeOutput/OutputHandler system with direct output.
-    Respects $env:NO_COLOR, supports Default/GitHubActions output formats,
-    and suppresses output in JSON/Quiet modes.
+    Respects $env:NO_COLOR, supports Default/GitHubActions/Annotated output
+    formats, and suppresses output in JSON/Quiet modes. Annotated mode emits
+    colored console output (same as Default) plus bare annotation lines for
+    errors and warnings via Write-BuildAnnotation.
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "PSAvoidUsingWriteHost",

--- a/src/private/Write-BuildMessage.ps1
+++ b/src/private/Write-BuildMessage.ps1
@@ -39,7 +39,7 @@ function Write-BuildMessage {
             return
         }
 
-        # Default console output
+        # Default console output (also used as the human-readable layer for Annotated mode)
         $useColor = -not (Test-Path env:NO_COLOR)
         if ($Type -eq 'Debug') {
             Write-Debug $Message
@@ -61,6 +61,18 @@ function Write-BuildMessage {
             }
         } else {
             Write-Host $Message
+        }
+
+        # Annotated mode: also emit a bare annotation line for errors and warnings
+        # so secondary matchers can pick them up. Informational types (Heading,
+        # Success, etc.) are intentionally skipped — only failures belong in the
+        # Problems panel. Positioned annotations with file/line are emitted
+        # separately by Invoke-BuildPlan when an error record is available.
+        if ($script:CurrentOutputFormat -eq 'Annotated') {
+            switch ($Type) {
+                'Error'   { Write-BuildAnnotation -Severity 'error'   -Message $Message }
+                'Warning' { Write-BuildAnnotation -Severity 'warning' -Message $Message }
+            }
         }
     }
 }

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -48,7 +48,7 @@ structured output for GitHub Actions, and JSON output for tooling integration.
 
     PrivateData          = @{
         PSData = @{
-            Prerelease   = 'alpha4'
+            Prerelease   = 'beta1'
             Tags         = @(
                 'Build'
                 'Task'

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -48,7 +48,7 @@ structured output for GitHub Actions, and JSON output for tooling integration.
 
     PrivateData          = @{
         PSData = @{
-            Prerelease   = 'beta1'
+            Prerelease   = 'beta2'
             Tags         = @(
                 'Build'
                 'Task'

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -167,8 +167,10 @@ function Invoke-Psake {
 
         # Apply env-var fallback when -OutputFormat was not explicitly passed
         if (-not $PSBoundParameters.ContainsKey('OutputFormat')) {
-            $validFormats = @('Default', 'JSON', 'GitHubActions', 'Annotated')
-            if ($env:PSAKE_OUTPUT_FORMAT -in $validFormats) {
+            $validateSet = $MyInvocation.MyCommand.Parameters['OutputFormat'].Attributes |
+                Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] } |
+                Select-Object -First 1
+            if ($validateSet -and $env:PSAKE_OUTPUT_FORMAT -in $validateSet.ValidValues) {
                 $OutputFormat = $env:PSAKE_OUTPUT_FORMAT
             }
         }

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -55,7 +55,9 @@ function Invoke-Psake {
 
     .PARAMETER OutputFormat
     The output format. 'Default' for console output, 'JSON' for JSON to stdout,
-    'GitHubActions' for GitHub Actions workflow annotations (::error::, ::warning::, ::debug::).
+    'GitHubActions' for GitHub Actions workflow annotations (::error::, ::warning::, ::debug::),
+    'Annotated' for colored console output plus annotation lines for errors/warnings (VS Code problem matcher).
+    If not specified, the PSAKE_OUTPUT_FORMAT environment variable is checked as a fallback.
 
     .PARAMETER NoCache
     Bypass task caching. All tasks will execute regardless of cache state.
@@ -134,7 +136,7 @@ function Invoke-Psake {
         [switch]$NoTimeReport,
 
         [Parameter(Mandatory = $false)]
-        [ValidateSet('Default', 'JSON', 'GitHubActions')]
+        [ValidateSet('Default', 'JSON', 'GitHubActions', 'Annotated')]
         [string]$OutputFormat = 'Default',
 
         [Parameter(Mandatory = $false)]
@@ -162,6 +164,14 @@ function Invoke-Psake {
         $script:Parameters = $Parameters
         $script:NoTimeReport = $NoTimeReport
         #endregion Store Script Variables
+
+        # Apply env-var fallback when -OutputFormat was not explicitly passed
+        if (-not $PSBoundParameters.ContainsKey('OutputFormat')) {
+            $validFormats = @('Default', 'JSON', 'GitHubActions', 'Annotated')
+            if ($env:PSAKE_OUTPUT_FORMAT -in $validFormats) {
+                $OutputFormat = $env:PSAKE_OUTPUT_FORMAT
+            }
+        }
 
         # Set output format for Write-BuildMessage
         $script:CurrentOutputFormat = if ($Quiet) { 'Quiet' } else { $OutputFormat }

--- a/tests/Write-BuildAnnotation.Tests.ps1
+++ b/tests/Write-BuildAnnotation.Tests.ps1
@@ -24,9 +24,10 @@ Describe 'Write-BuildAnnotation' {
                     -File 'C:\build\test.ps1' -Line 42 -Column 5 `
                     -Title 'MyTask' -Message 'Something failed'
             }
+            # Colon in C:\ is escaped to %3A per GitHub Actions escapeProperty spec
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
-                    $Object -eq '::error file=C:\build\test.ps1,line=42,col=5,title=MyTask::Something failed'
+                    $Object -eq '::error file=C%3A\build\test.ps1,line=42,col=5,title=MyTask::Something failed'
                 }
         }
 
@@ -51,6 +52,42 @@ Describe 'Write-BuildAnnotation' {
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
                     $Object -match '%0A' -and $Object -notmatch "line1`nline2"
+                }
+        }
+
+        It 'File path with colon escapes it to %3A' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -File 'D:\src\app.ps1' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match 'file=D%3A\\src\\app\.ps1' -and $Object -notmatch 'file=D:\\src'
+                }
+        }
+
+        It 'File path with comma escapes it to %2C' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -File 'path,with,commas.ps1' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match 'file=path%2Cwith%2Ccommas' -and $Object -notmatch 'file=path,with'
+                }
+        }
+
+        It 'Title with newlines escapes them to %0A and %0D' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -Title "line1`r`nline2" -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match '%0D%0A' -and $Object -notmatch "title=line1`r`nline2"
                 }
         }
 

--- a/tests/Write-BuildAnnotation.Tests.ps1
+++ b/tests/Write-BuildAnnotation.Tests.ps1
@@ -1,0 +1,172 @@
+BeforeDiscovery {
+    if ($null -eq $env:BHProjectName) {
+        .\build.ps1 -Task Build
+    }
+    $manifest = Import-PowerShellDataFile -Path $env:BHPSModuleManifest
+    $outputDir = Join-Path -Path $env:BHProjectPath -ChildPath 'output'
+    $outputModDir = Join-Path -Path $outputDir -ChildPath $env:BHProjectName
+    $outputModVerDir = Join-Path -Path $outputModDir -ChildPath $manifest.ModuleVersion
+    $outputModVerManifest = Join-Path -Path $outputModVerDir -ChildPath "$($env:BHProjectName).psd1"
+
+    Get-Module $env:BHProjectName | Remove-Module -Force -ErrorAction Ignore
+    Import-Module -Name $outputModVerManifest -Verbose:$false -ErrorAction Stop
+}
+
+Describe 'Write-BuildAnnotation' {
+
+    Context 'Annotation string format' {
+
+        It 'Error with full position emits correct annotation string' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' `
+                    -File 'C:\build\test.ps1' -Line 42 -Column 5 `
+                    -Title 'MyTask' -Message 'Something failed'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -eq '::error file=C:\build\test.ps1,line=42,col=5,title=MyTask::Something failed'
+                }
+        }
+
+        It 'Warning with no file/line/col emits only title and message' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'warning' -Title 'TaskName' -Message 'a warning message'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -eq '::warning title=TaskName::a warning message'
+                }
+        }
+
+        It 'Message with newlines escapes them to %0A' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -Message "line1`nline2"
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match '%0A' -and $Object -notmatch "line1`nline2"
+                }
+        }
+
+        It 'Title with comma escapes it to %2C' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -Title 'Build,Deploy' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match '%2C' -and $Object -notmatch 'title=Build,Deploy'
+                }
+        }
+
+        It 'Title with colon escapes it to %3A' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -Title 'Build:Release' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match '%3A'
+                }
+        }
+
+        It 'Omits zero Line and Column fields' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Annotated'
+                Write-BuildAnnotation -Severity 'error' -File 'build.ps1' -Line 0 -Column 0 -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -notmatch 'line=' -and $Object -notmatch 'col='
+                }
+        }
+
+        It 'Produces output in GitHubActions format' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'GitHubActions'
+                Write-BuildAnnotation -Severity 'error' -File 'test.ps1' -Line 1 -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly
+        }
+
+        It 'Produces no output in Default format' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'Default'
+                Write-BuildAnnotation -Severity 'error' -File 'test.ps1' -Line 1 -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 0
+        }
+
+        It 'Produces no output in JSON format' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'JSON'
+                Write-BuildAnnotation -Severity 'error' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 0
+        }
+    }
+
+    Context 'OutputFormat env-var fallback and integration' {
+        BeforeAll {
+            $script:specFolder = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..') -ChildPath 'specs'
+            $psake.run_by_psake_build_tester = $true
+        }
+
+        AfterEach {
+            Remove-Item Env:\PSAKE_OUTPUT_FORMAT -ErrorAction Ignore
+        }
+
+        It 'Env-var PSAKE_OUTPUT_FORMAT=Annotated activates annotation output' {
+            $env:PSAKE_OUTPUT_FORMAT = 'Annotated'
+            $buildFile = Join-Path $script:specFolder 'annotated_output_format_failing_task_should_fail.ps1'
+            $output = Invoke-Psake -BuildFile $buildFile -NoLogo 6>&1 | Out-String
+            $output | Should -Match '::error'
+        }
+
+        It 'Env-var is ignored when -OutputFormat Default is passed explicitly' {
+            $env:PSAKE_OUTPUT_FORMAT = 'Annotated'
+            $buildFile = Join-Path $script:specFolder 'annotated_output_format_failing_task_should_fail.ps1'
+            $output = Invoke-Psake -BuildFile $buildFile -NoLogo -OutputFormat Default 6>&1 | Out-String
+            # Bare ::error lines (without file=) would come from Write-BuildMessage;
+            # neither those nor positioned ::error file= lines should appear in Default mode
+            $output | Should -Not -Match '::error file='
+            $output | Should -Not -Match '::error::'
+        }
+
+        It 'Annotated mode emits both human-readable output and annotation lines' {
+            $buildFile = Join-Path $script:specFolder 'annotated_output_format_failing_task_should_fail.ps1'
+            $output = Invoke-Psake -BuildFile $buildFile -NoLogo -OutputFormat Annotated 6>&1 | Out-String
+            # Human-readable error text is present (the formatted error message)
+            $output | Should -Not -BeNullOrEmpty
+            # Positioned annotation line is also present
+            $output | Should -Match '::error'
+        }
+
+        It 'Default mode emits no annotation lines' {
+            $buildFile = Join-Path $script:specFolder 'annotated_output_format_failing_task_should_fail.ps1'
+            $output = Invoke-Psake -BuildFile $buildFile -NoLogo -OutputFormat Default 6>&1 | Out-String
+            $output | Should -Not -Match '::error file='
+            $output | Should -Not -Match '::error::'
+        }
+
+        It 'Invalid env-var value falls back to Default (no annotations)' {
+            $env:PSAKE_OUTPUT_FORMAT = 'NotAValidFormat'
+            $buildFile = Join-Path $script:specFolder 'annotated_output_format_failing_task_should_fail.ps1'
+            $output = Invoke-Psake -BuildFile $buildFile -NoLogo 6>&1 | Out-String
+            $output | Should -Not -Match '::error file='
+            $output | Should -Not -Match '::error::'
+        }
+    }
+}


### PR DESCRIPTION
- Add 'Annotated' to [ValidateSet] on -OutputFormat parameter
- When -OutputFormat is not explicitly passed, check $env:PSAKE_OUTPUT_FORMAT
  and apply it if it contains a valid format name; otherwise fall back to Default
- Update parameter help text to document the new mode and env-var fallback

https://claude.ai/code/session_013zT7prxgZJtC3zbMp4RnP8