### PR TITLE
fix(annotated-output): preserve ':' and ',' for VS Code + 5.0.0-beta3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `Write-BuildAnnotation` now escapes all property values (file,
-  title) per the GitHub Actions `escapeProperty` spec — colons,
-  commas, newlines, and carriage returns are percent-encoded in
-  all property fields, not just title
+- `Write-BuildAnnotation` escaping is now mode-aware. In
+  `GitHubActions` mode, property values follow the full
+  `escapeProperty` spec (%, \r, \n, :, ,). In `Annotated` mode
+  (VS Code problem matchers), `:` and `,` are preserved in
+  property values because VS Code's regex-based matcher does
+  not unescape them — escaping them would produce unresolvable
+  file paths like `C%3A\build\test.ps1`.
 - `Exec` now captures and displays full command output (stdout
   and stderr) on failure — many CLI tools like Chocolatey write
   errors to stdout, which was previously invisible

--- a/src/private/Write-BuildAnnotation.ps1
+++ b/src/private/Write-BuildAnnotation.ps1
@@ -13,19 +13,19 @@ function Write-BuildAnnotation {
     Fields are omitted when empty or zero. Field ordering is fixed (file, line,
     col, title) because the VS Code problem matcher regex depends on it.
 
-    Escaping follows the GitHub Actions workflow command specification:
+    Escaping varies by output format because the consumers differ:
 
-    Property values (file, title, etc.):
-        %  -> %25  (encoded first to avoid double-encoding)
-        \r -> %0D
-        \n -> %0A
-        :  -> %3A
-        ,  -> %2C
+    GitHubActions mode — GitHub's runner decodes escapes before use.
+    Full escapeProperty spec from actions/toolkit:
+        Property values:  %->%25  \r->%0D  \n->%0A  :->%3A  ,->%2C
+        Message (data):   %->%25  \r->%0D  \n->%0A
 
-    Message (data) value:
-        %  -> %25
-        \r -> %0D
-        \n -> %0A
+    Annotated mode — VS Code problem matchers are pure regex; they do
+    NOT unescape percent-encoded values. Escaping : and , in file
+    paths would produce literal C%3A\build\test.ps1 which VS Code
+    cannot resolve. Only structural escapes are applied:
+        Property values:  %->%25  \r->%0D  \n->%0A
+        Message (data):   %->%25  \r->%0D  \n->%0A
     #>
     [System.Diagnostics.CodeAnalysis.SuppressMessage(
         "PSAvoidUsingWriteHost",
@@ -51,15 +51,19 @@ function Write-BuildAnnotation {
         return
     }
 
-    # Escape per GitHub Actions spec — percent first to avoid double-encoding.
-    # Property values need all five escapes; the message (data) needs only three.
+    # Escape percent first to avoid double-encoding, then structural chars.
     $escapedMessage = $Message -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+
+    # GitHubActions: full escapeProperty spec (runner decodes before use)
+    # Annotated:     skip : and , (VS Code regex uses the raw string)
+    $fullEscape = $script:CurrentOutputFormat -eq 'GitHubActions'
 
     # Build optional fields in the fixed order required by the VS Code regex:
     # file, line, col, title
     $fields = [System.Collections.Generic.List[string]]::new()
     if (-not [string]::IsNullOrEmpty($File)) {
-        $escapedFile = $File -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
+        $escapedFile = $File -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+        if ($fullEscape) { $escapedFile = $escapedFile -replace ':', '%3A' -replace ',', '%2C' }
         $fields.Add("file=$escapedFile")
     }
     if ($Line -gt 0) {
@@ -69,7 +73,8 @@ function Write-BuildAnnotation {
         $fields.Add("col=$Column")
     }
     if (-not [string]::IsNullOrEmpty($Title)) {
-        $escapedTitle = $Title -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A' -replace ':', '%3A' -replace ',', '%2C'
+        $escapedTitle = $Title -replace '%', '%25' -replace "`r", '%0D' -replace "`n", '%0A'
+        if ($fullEscape) { $escapedTitle = $escapedTitle -replace ':', '%3A' -replace ',', '%2C' }
         $fields.Add("title=$escapedTitle")
     }
 

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -48,7 +48,7 @@ structured output for GitHub Actions, and JSON output for tooling integration.
 
     PrivateData          = @{
         PSData = @{
-            Prerelease   = 'beta2'
+            Prerelease   = 'beta3'
             Tags         = @(
                 'Build'
                 'Task'

--- a/tests/Write-BuildAnnotation.Tests.ps1
+++ b/tests/Write-BuildAnnotation.Tests.ps1
@@ -24,10 +24,10 @@ Describe 'Write-BuildAnnotation' {
                     -File 'C:\build\test.ps1' -Line 42 -Column 5 `
                     -Title 'MyTask' -Message 'Something failed'
             }
-            # Colon in C:\ is escaped to %3A per GitHub Actions escapeProperty spec
+            # Annotated mode preserves colons for VS Code path resolution
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
-                    $Object -eq '::error file=C%3A\build\test.ps1,line=42,col=5,title=MyTask::Something failed'
+                    $Object -eq '::error file=C:\build\test.ps1,line=42,col=5,title=MyTask::Something failed'
                 }
         }
 
@@ -55,7 +55,7 @@ Describe 'Write-BuildAnnotation' {
                 }
         }
 
-        It 'File path with colon escapes it to %3A' {
+        It 'Annotated mode preserves colons and commas in file paths for VS Code' {
             Mock -CommandName Write-Host -ModuleName psake
             InModuleScope psake {
                 $script:CurrentOutputFormat = 'Annotated'
@@ -63,23 +63,47 @@ Describe 'Write-BuildAnnotation' {
             }
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
-                    $Object -match 'file=D%3A\\src\\app\.ps1' -and $Object -notmatch 'file=D:\\src'
+                    $Object -match 'file=D:\\src\\app\.ps1'
                 }
         }
 
-        It 'File path with comma escapes it to %2C' {
+        It 'Annotated mode preserves colons and commas in title' {
             Mock -CommandName Write-Host -ModuleName psake
             InModuleScope psake {
                 $script:CurrentOutputFormat = 'Annotated'
-                Write-BuildAnnotation -Severity 'error' -File 'path,with,commas.ps1' -Message 'test'
+                Write-BuildAnnotation -Severity 'error' -Title 'Build:Release,Deploy' -Message 'test'
             }
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
-                    $Object -match 'file=path%2Cwith%2Ccommas' -and $Object -notmatch 'file=path,with'
+                    $Object -match 'title=Build:Release,Deploy'
                 }
         }
 
-        It 'Title with newlines escapes them to %0A and %0D' {
+        It 'GitHubActions mode escapes colons to %3A in file paths' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'GitHubActions'
+                Write-BuildAnnotation -Severity 'error' -File 'D:\src\app.ps1' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match 'file=D%3A\\src\\app\.ps1'
+                }
+        }
+
+        It 'GitHubActions mode escapes commas and colons in title' {
+            Mock -CommandName Write-Host -ModuleName psake
+            InModuleScope psake {
+                $script:CurrentOutputFormat = 'GitHubActions'
+                Write-BuildAnnotation -Severity 'error' -Title 'Build:Release,Deploy' -Message 'test'
+            }
+            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
+                -ParameterFilter {
+                    $Object -match 'title=Build%3ARelease%2CDeploy'
+                }
+        }
+
+        It 'Title with newlines escapes them to %0A and %0D in both modes' {
             Mock -CommandName Write-Host -ModuleName psake
             InModuleScope psake {
                 $script:CurrentOutputFormat = 'Annotated'
@@ -88,30 +112,6 @@ Describe 'Write-BuildAnnotation' {
             Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
                 -ParameterFilter {
                     $Object -match '%0D%0A' -and $Object -notmatch "title=line1`r`nline2"
-                }
-        }
-
-        It 'Title with comma escapes it to %2C' {
-            Mock -CommandName Write-Host -ModuleName psake
-            InModuleScope psake {
-                $script:CurrentOutputFormat = 'Annotated'
-                Write-BuildAnnotation -Severity 'error' -Title 'Build,Deploy' -Message 'test'
-            }
-            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
-                -ParameterFilter {
-                    $Object -match '%2C' -and $Object -notmatch 'title=Build,Deploy'
-                }
-        }
-
-        It 'Title with colon escapes it to %3A' {
-            Mock -CommandName Write-Host -ModuleName psake
-            InModuleScope psake {
-                $script:CurrentOutputFormat = 'Annotated'
-                Write-BuildAnnotation -Severity 'error' -Title 'Build:Release' -Message 'test'
-            }
-            Should -Invoke -CommandName Write-Host -ModuleName psake -Times 1 -Exactly `
-                -ParameterFilter {
-                    $Object -match '%3A'
                 }
         }
 


### PR DESCRIPTION
## Summary

- Fix `Write-BuildAnnotation` escaping to be mode-aware: full
  `escapeProperty` spec in `GitHubActions` mode, minimal
  structural escapes in `Annotated` mode
- Bump prerelease to `5.0.0-beta3`

## Background

PR #364 landed escaping that follows the GitHub Actions toolkit
`escapeProperty` spec for all annotation property values (including
`:` and `,`). That's correct for GitHub Actions — the runner decodes
these before consuming them.

**However**, VS Code problem matchers are pure regex. They do NOT
unescape percent-encoded values. In `Annotated` mode, this meant
Windows paths like `C:\build\test.ps1` were being emitted as
`C%3A\build\test.ps1`, which VS Code could not resolve. The Problems
panel silently broke on Windows.

## Fix

`Write-BuildAnnotation` now branches on the current output format:

| Mode          | Escapes applied to property values   |
|---------------|--------------------------------------|
| GitHubActions | `%`, `\r`, `\n`, `:`, `,` (full spec)|
| Annotated     | `%`, `\r`, `\n` (structural only)    |

Message (data) escaping is unchanged in both modes.

## Test plan

- [x] Unit tests for both modes: 17 passing locally
  - `Annotated mode preserves colons and commas in file paths for VS Code`
  - `Annotated mode preserves colons and commas in title`
  - `GitHubActions mode escapes colons to %3A in file paths`
  - `GitHubActions mode escapes commas and colons in title`
- [ ] Verify in a real VS Code workspace that clicking an
  annotated error navigates to the correct Windows file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)