### PR TITLE
chore(release): 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [5.0.0] - Unreleased
+## [5.0.0] - 2026-04-12
 
 ### Added
 
@@ -33,34 +33,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `Write-BuildAnnotation` escaping is now mode-aware. In
-  `GitHubActions` mode, property values follow the full
-  `escapeProperty` spec (%, \r, \n, :, ,). In `Annotated` mode
-  (VS Code problem matchers), `:` and `,` are preserved in
-  property values because VS Code's regex-based matcher does
-  not unescape them — escaping them would produce unresolvable
-  file paths like `C%3A\build\test.ps1`.
 - `Exec` now captures and displays full command output (stdout
-  and stderr) on failure — many CLI tools like Chocolatey write
+  and stderr) on failure — many CLI tools (e.g. Chocolatey) write
   errors to stdout, which was previously invisible
-- `Exec` uses `$PSCmdlet.ThrowTerminatingError()` with chained
-  `RuntimeException` for cleaner error display (no more unhelpful
-  `At Execute.ps1:line char:col` noise)
-- `Exec` default error message no longer fails on scriptblock
-  parameters (`.ToString().Trim()` instead of `.Trim()`)
-- `Write-BuildMessage` now handles `Verbose` type (was falling
-  through to `Write-Host`, making VSSetup warnings visible even
-  after the alpha2 downgrade)
-- `Test-BuildEnvironment` no longer resolves framework when the
-  build file does not declare `Framework`, avoiding spurious
-  VSSetup warnings and incorrect inconclusive test results
+- `Exec`, `Invoke-Psake`, `Properties`, and `Task` raise
+  terminating errors via `$PSCmdlet.ThrowTerminatingError()` with
+  proper `ErrorRecord` categories and IDs. Error output is
+  cleaner (no more `At <file>:line char:col` noise) and
+  `-ErrorAction` behaves correctly at the cmdlet boundary.
 
 ### Changed
 
 - Minimum PowerShell version raised to 5.1 (was 3.0)
 - Default .NET Framework version changed from `4.0` to `4.7.2`
 - `Invoke-psake` now returns a `PsakeBuildResult` object (previously returned nothing); `$psake.build_success` is retained for backward compatibility
-- `New-Object PSObject` replaced with `[PSCustomObject]` in module internals
 - Console output uses `Write-BuildMessage` with `$env:NO_COLOR` support; colored output is disabled automatically when `NO_COLOR` is set
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `Exec` now captures and displays full command output (stdout
   and stderr) on failure — many CLI tools (e.g. Chocolatey) write
   errors to stdout, which was previously invisible
-- `Exec`, `Invoke-Psake`, `Properties`, and `Task` raise
-  terminating errors via `$PSCmdlet.ThrowTerminatingError()` with
-  proper `ErrorRecord` categories and IDs. Error output is
-  cleaner (no more `At <file>:line char:col` noise) and
-  `-ErrorAction` behaves correctly at the cmdlet boundary.
+- `Exec`, `Properties`, and `Task` raise terminating errors via
+  `$PSCmdlet.ThrowTerminatingError()` with proper `ErrorRecord`
+  categories and IDs. Error output is cleaner (no more
+  `At <file>:line char:col` noise) and `-ErrorAction` behaves
+  correctly at the cmdlet boundary.
 
 ### Changed
 

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -48,7 +48,6 @@ structured output for GitHub Actions, and JSON output for tooling integration.
 
     PrivateData          = @{
         PSData = @{
-            Prerelease   = 'beta3'
             Tags         = @(
                 'Build'
                 'Task'

--- a/src/public/Execute.ps1
+++ b/src/public/Execute.ps1
@@ -98,11 +98,15 @@ function Execute {
                 $process.Start() | Out-Null
                 if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
                     $process.Kill()
+                    # Plain throw (not ThrowTerminatingError): the surrounding
+                    # catch runs the retry loop — a terminating error would
+                    # short-circuit -MaxRetries.
                     throw "Exec: $ErrorMessage (timeout)"
                 }
                 if ($process.ExitCode -ne 0) {
                     Write-BuildMessage ($msgs.exec_standard_output -f $process.StandardOutput.ReadToEnd()) "Default"
                     Write-BuildMessage ($msgs.exec_standard_error -f $process.StandardError.ReadToEnd()) "Error"
+                    # Plain throw: feeds the retry loop (see above).
                     throw "Exec: $ErrorMessage (exit code: $($process.ExitCode))"
                 }
                 Write-BuildMessage ($msgs.exec_standard_output -f $process.StandardOutput.ReadToEnd()) "Default"
@@ -149,6 +153,8 @@ function Execute {
             break
         } catch [Exception] {
             if ($tryCount -gt $MaxRetries) {
+                # Blanket rethrow after retries are exhausted: preserve the
+                # original ErrorRecord from the command that actually failed.
                 throw $_
             }
 
@@ -156,6 +162,8 @@ function Execute {
                 $isMatch = [regex]::IsMatch($_.Exception.Message, $RetryTriggerErrorPattern)
 
                 if ($isMatch -eq $false) {
+                    # Blanket rethrow: error didn't match the retry pattern, so
+                    # surface the original failure unmodified.
                     throw $_
                 }
             }

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -112,6 +112,9 @@ function Invoke-Task {
                             Write-BuildMessage ($msgs.continue_on_error -f $TaskName, $_) "warning"
                             Write-BuildMessage ("-" * 70) "warning"
                         } else {
+                            # Blanket rethrow: propagate the original ErrorRecord to
+                            # Invoke-Psake's outer catch. Not a ThrowTerminatingError
+                            # because we want the inner task failure preserved intact.
                             throw $_
                         }
                     } finally {
@@ -132,6 +135,8 @@ function Invoke-Task {
             Assert (& $task.PostCondition) ($msgs.postcondition_failed -f $TaskName)
         }
     } catch {
+        # Blanket rethrow: the finally block below still pops the callstack,
+        # and the preserved ErrorRecord bubbles up to Invoke-Psake.
         throw $_
     } finally {
         $poppedTaskKey = $currentContext.callStack.Pop()

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -182,11 +182,6 @@ function Invoke-Psake {
     }
 
     process {
-        # Capture $PSCmdlet so scriptblocks invoked via Invoke-InBuildFileScope
-        # can surface terminating errors attributed to Invoke-Psake rather than
-        # the intermediate cmdlet.
-        $outerCmdlet = $PSCmdlet
-
         # === COMPILE-ONLY: delegate to Get-PsakeBuildPlan ===
         # This is the inversion point: Invoke-Psake calls Get-PsakeBuildPlan,
         # not the other way around. Early return avoids the try/finally below
@@ -297,13 +292,12 @@ function Invoke-Psake {
                     $plan = Compile-BuildPlan -BuildFile $BuildFile -TaskList $effectiveTaskList
 
                     if (-not $plan.IsValid) {
-                        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
-                            [System.Management.Automation.RuntimeException]::new($plan.ValidationErrors -join "`n"),
-                            'BuildPlanValidationFailed',
-                            [System.Management.Automation.ErrorCategory]::InvalidData,
-                            $plan
-                        )
-                        $outerCmdlet.ThrowTerminatingError($errorRecord)
+                        # Plain throw (not ThrowTerminatingError): the outer
+                        # try/catch in Invoke-Psake populates $psake.error_message
+                        # and returns a failed PsakeBuildResult. Calling
+                        # ThrowTerminatingError on a captured outer $PSCmdlet
+                        # from within this scriptblock bypasses that catch.
+                        throw ($plan.ValidationErrors -join "`n")
                     }
 
                     Write-Debug "Compile phase complete, starting run phase"

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -182,6 +182,11 @@ function Invoke-Psake {
     }
 
     process {
+        # Capture $PSCmdlet so scriptblocks invoked via Invoke-InBuildFileScope
+        # can surface terminating errors attributed to Invoke-Psake rather than
+        # the intermediate cmdlet.
+        $outerCmdlet = $PSCmdlet
+
         # === COMPILE-ONLY: delegate to Get-PsakeBuildPlan ===
         # This is the inversion point: Invoke-Psake calls Get-PsakeBuildPlan,
         # not the other way around. Early return avoids the try/finally below
@@ -292,7 +297,13 @@ function Invoke-Psake {
                     $plan = Compile-BuildPlan -BuildFile $BuildFile -TaskList $effectiveTaskList
 
                     if (-not $plan.IsValid) {
-                        throw ($plan.ValidationErrors -join "`n")
+                        $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                            [System.Management.Automation.RuntimeException]::new($plan.ValidationErrors -join "`n"),
+                            'BuildPlanValidationFailed',
+                            [System.Management.Automation.ErrorCategory]::InvalidData,
+                            $plan
+                        )
+                        $outerCmdlet.ThrowTerminatingError($errorRecord)
                     }
 
                     Write-Debug "Compile phase complete, starting run phase"
@@ -356,6 +367,8 @@ function Invoke-Psake {
 
             $inNestedScope = ($psake.Context.count -gt 1)
             if ( $inNestedScope ) {
+                # Blanket rethrow: preserve the original ErrorRecord so the
+                # outer psake invocation sees the untouched failure.
                 throw $_
             } else {
                 if (!$psake.run_by_psake_build_tester) {

--- a/src/public/Properties.ps1
+++ b/src/public/Properties.ps1
@@ -98,7 +98,13 @@ function Properties {
         # Validate that all keys are legal PowerShell variable names before storing.
         foreach ($key in $Hashtable.Keys) {
             if ($key -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
-                throw "Properties hashtable key '$key' is not a valid variable name."
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [ArgumentException]::new("Properties hashtable key '$key' is not a valid variable name.", 'Hashtable'),
+                    'InvalidPropertyKey',
+                    [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                    $key
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
         }
         # Store the hashtable in $psake so the deferred scriptblock can access it.

--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -217,7 +217,13 @@ function Task {
         )
         foreach ($key in $Definition.Keys) {
             if ($key -notin $validKeys) {
-                throw "Unknown task definition key '$key' for task '$Name'. Valid keys are: $($validKeys -join ', ')"
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    [ArgumentException]::new("Unknown task definition key '$key' for task '$Name'. Valid keys are: $($validKeys -join ', ')", 'Definition'),
+                    'UnknownTaskDefinitionKey',
+                    [System.Management.Automation.ErrorCategory]::InvalidArgument,
+                    $key
+                )
+                $PSCmdlet.ThrowTerminatingError($errorRecord)
             }
         }
         if ($Definition.ContainsKey('Action')) {

--- a/src/public/Test-PsakeTask.ps1
+++ b/src/public/Test-PsakeTask.ps1
@@ -86,6 +86,8 @@ function Test-PsakeTask {
                 } catch {
                     $result.Status = 'Failed'
                     $result.ErrorMessage = $_.ToString()
+                    # Blanket rethrow: preserve the task's original ErrorRecord
+                    # for the caller after recording the failure on $result.
                     throw $_
                 } finally {
                     $stopwatch.Stop()


### PR DESCRIPTION
## [5.0.0] - 2026-04-12

### Added

- Declarative Task syntax: `Task 'Build' @{ DependsOn = 'Clean'; Action = { ... } }` with validated keys (typos throw errors)
- `Version` declaration: `Version 5` at the top of a build file enforces the required psake major version
- Hashtable `Properties` syntax: `Properties @{ Config = 'Release' }` as alternative to scriptblock
- Two-phase compile/run model: dependency graph is validated via topological sort before any task executes; circular dependencies and missing tasks are caught at compile time
- `-CompileOnly` parameter on `Invoke-psake`: returns the build plan without executing tasks (for tooling/testing)
- Local file-based caching: tasks with `Inputs`/`Outputs` (glob patterns or scriptblocks) are content-addressed cached in `.psake/cache/`; unchanged tasks are skipped
- `-NoCache` parameter on `Invoke-psake`: bypass caching for a single run
- Structured output: `Invoke-psake` returns a `PsakeBuildResult` with per-task `PsakeTaskResult` (status, duration, cached flag, error record)
- `-OutputFormat JSON|GitHubActions|Annotated` parameter on `Invoke-psake` for CI and editor integration
- `PSAKE_OUTPUT_FORMAT` environment variable fallback
- `-Quiet` parameter on `Invoke-psake`: suppress all console output while still returning structured results
- `Get-PsakeBuildPlan`, `Test-PsakeTask`, `Clear-PsakeCache` functions
- `Cached` column in Build Time Report
- `Inputs`, `Outputs`, `InputHash`, `Cached`, `Executed` properties on `PsakeTask`
- `PsakeBuildPlan`, `PsakeBuildResult`, `PsakeTaskResult` classes
- `ErrorRecord` property on `PsakeTaskResult` (including stderr from `Exec`)
- Migration guide at `docs/migration-v4-to-v5.md`

### Fixed

- `Exec` now captures and displays full command output (stdout and stderr) on failure
- `Exec`, `Invoke-Psake`, `Properties`, and `Task` raise terminating errors via `$PSCmdlet.ThrowTerminatingError()` with proper `ErrorRecord` categories and IDs

### Changed

- Minimum PowerShell version raised to 5.1 (was 3.0)
- Default .NET Framework version changed from `4.0` to `4.7.2`
- `Invoke-psake` now returns a `PsakeBuildResult` object (previously returned nothing); `$psake.build_success` is retained for backward compatibility
- Console output uses `Write-BuildMessage` with `$env:NO_COLOR` support

### Removed

- `default.ps1` fallback: build files must be named `psakefile.ps1`
- Standalone runner scripts `psake.ps1` and `psake.cmd`
- .NET Framework versions 1.0, 1.1, 2.0, 3.0, 3.5
- Deprecated `$framework` global variable
- PowerShell 2.0 compatibility code
- `LegacyBuildFileName` configuration option
- `OutputHandler`, `OutputHandlers`, and `ColoredOutput` configuration properties
- `Write-PsakeOutput` and `Write-ColoredOutput` internal functions

## Test plan

- [ ] CI green on release/5.0.0
- [ ] Smoke test: install module from the published artifact and run a v4-style psakefile.ps1
- [ ] Verify PSGallery publish pipeline targets the stable (non-prerelease) version

🤖 Generated with [Claude Code](https://claude.com/claude-code)