### PR TITLE
fix(publish): repair Chocolatey icon and NuGet push steps

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -271,6 +271,19 @@ function PublishChocolatey {
     [CmdletBinding()]
     param()
 
+    # Chocolatey CLI rejects <icon> (CHCU0002); rewrite the staged nuspec to use <iconUrl>.
+    $specPath = "$outputNugetDir\psake.nuspec"
+    $spec = [xml](Get-Content -Raw $specPath)
+    $metadata = $spec.package.metadata
+    $iconNode = $metadata.SelectSingleNode('*[local-name()="icon"]')
+    if ($iconNode) { [void]$metadata.RemoveChild($iconNode) }
+    if (-not $metadata.SelectSingleNode('*[local-name()="iconUrl"]')) {
+        $iconUrl = $spec.CreateElement('iconUrl', $spec.DocumentElement.NamespaceURI)
+        $iconUrl.InnerText = 'https://raw.githubusercontent.com/psake/graphics/main/png/psake-single-icon-teal-bg-256x256.png'
+        [void]$metadata.AppendChild($iconUrl)
+    }
+    $spec.Save($specPath)
+
     try {
         Push-Location $outputNugetDir
         choco pack
@@ -289,22 +302,15 @@ function PublishNuget {
     param()
 
     "Building nuget package version [$version]"
-    $nugetInPath = Get-Command 'nuget' -ErrorAction 'SilentlyContinue'
-    if (-not $nugetInPath) {
-        Write-Warning "Nuget not detected in path. Using local copy..."
-        $nugetBin = Resolve-Path "$PSScriptRoot\build\nuget\NuGet.exe"
-    } else {
-        $nugetBin = $nugetInPath.Source
-    }
-    Write-Verbose "Using nuget at $nugetBin"
     try {
         Push-Location $outputNugetDir
+        $nugetBin = Resolve-Path "$PSScriptRoot\build\nuget\NuGet.exe"
         & $nugetBin pack "./psake.nuspec" -Verbosity quiet -Version $version -Properties NoWarn='NU5111,NU5125'
         $nupkg = (Get-ChildItem "psake*.nupkg").Name
         if ($null -eq $ENV:NUGET_API_KEY) {
             throw 'Nuget API is not set! Not publishing.'
         }
-        & $nugetBin push $nupkg --api-key $ENV:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+        dotnet nuget push $nupkg --api-key $ENV:NUGET_API_KEY --source https://api.nuget.org/v3/index.json
     } finally {
         Pop-Location
     }


### PR DESCRIPTION
## Summary
- `PublishChocolatey` now rewrites the staged nuspec in-place to swap `<icon>` for `<iconUrl>` before `choco pack`. The `<icon>` tag (added in 3c86c32) is valid for modern NuGet but Chocolatey CLI v2 rejects it with `CHCU0002`, which broke the 5.0.0 publish run.
- `PublishNuget` switches to `dotnet nuget push`, which natively accepts the existing `--api-key`/`--source` flags. Classic `nuget.exe push` expects `-ApiKey`/`-Source`, so the call was failing with `Unknown option: '--api-key'`.
- Source nuspec keeps the embedded `<icon>icon.png</icon>` so the NuGet package still ships the icon; the Chocolatey mutation is scoped to the staged copy under `output/nuget/`.

## Test plan
- [ ] Re-run the Publish workflow against the 5.0.0 tag (or a dry-run build) and confirm both Publish Chocolatey Package and Publish nuget Package jobs succeed.
- [ ] Verify the published NuGet package on nuget.org renders the embedded icon.
- [ ] Verify the Chocolatey package page renders the icon from the `iconUrl`.

Refs failing run: https://github.com/psake/psake/actions/runs/24355495137

🤖 Generated with [Claude Code](https://claude.com/claude-code)