### PR TITLE
chore(release): 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.1] - 2026-04-14
+
+### Fixed
+
+- Crash when `Invoke-psake` or `Get-PsakeBuildPlan` is called with a
+  bare build-file name (no directory component), e.g. `psake.cmd
+  TaskName` resolving `psakefile.ps1`. `Split-Path` returned an empty
+  string, causing `Join-Path` to throw. Now falls back to the current
+  working directory. (issue #368)
+
 ## [5.0.0] - 2026-04-12
 
 ### Added

--- a/specs/cmd_invocation/psakefile.ps1
+++ b/specs/cmd_invocation/psakefile.ps1
@@ -1,3 +1,5 @@
-task default {
+task default -depends noop
+
+task noop {
     # Minimal task - exists to verify cmd-style invocation succeeds
 }

--- a/specs/cmd_invocation/psakefile.ps1
+++ b/specs/cmd_invocation/psakefile.ps1
@@ -1,0 +1,3 @@
+task default {
+    # Minimal task - exists to verify cmd-style invocation succeeds
+}

--- a/specs/cmd_style_task_invocation_should_pass.ps1
+++ b/specs/cmd_style_task_invocation_should_pass.ps1
@@ -1,0 +1,21 @@
+# Regression test for issue #368.
+# Users invoke psake via psake.cmd passing a task name as the first positional
+# argument (e.g. "psake.cmd CI 1.0.0"). Invoke-psake detects that the argument
+# is not a file, looks up the default build file, and calls Compile-BuildPlan
+# with a bare filename ('psakefile.ps1', no directory component).
+# Split-Path on a bare filename returns '', causing Join-Path to throw:
+#   "Cannot bind argument to parameter 'Path' because it is an empty string."
+
+task default -depends test
+
+task test {
+    Push-Location (Join-Path $psake.build_script_dir 'cmd_invocation')
+    try {
+        # Simulate: psake.cmd default
+        # 'default' is treated as BuildFile by Invoke-psake (position 0),
+        # which detects it is not a file and falls back to psakefile.ps1.
+        Invoke-psake 'default' -NoLogo
+    } finally {
+        Pop-Location
+    }
+}

--- a/specs/cmd_style_task_invocation_should_pass.ps1
+++ b/specs/cmd_style_task_invocation_should_pass.ps1
@@ -1,3 +1,4 @@
+# Requires: Windows
 # Regression test for issue #368.
 # Users invoke psake via psake.cmd passing a task name as the first positional
 # argument (e.g. "psake.cmd CI 1.0.0"). Invoke-psake detects that the argument

--- a/src/private/Compile-BuildPlan.ps1
+++ b/src/private/Compile-BuildPlan.ps1
@@ -32,6 +32,7 @@ function Compile-BuildPlan {
     $plan.BuildFile = $BuildFile
     $plan.CompiledAt = [datetime]::UtcNow
     $buildPath = Split-Path $BuildFile -Parent
+    if ([string]::IsNullOrEmpty($buildPath)) { $buildPath = (Get-Location).Path }
     $psakeDir = Join-Path $buildPath '.psake'
     $plan.CacheDir = Join-Path $psakeDir 'cache'
     $plan.ValidationErrors = @()

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'psake.psm1'
-    ModuleVersion        = '5.0.0'
+    ModuleVersion        = '5.0.1'
     GUID                 = 'cfb53216-072f-4a46-8975-ff7e6bda05a5'
     Author               = 'James Kovacs'
     CompanyName          = 'psake'

--- a/tests/Compile-BuildPlan.tests.ps1
+++ b/tests/Compile-BuildPlan.tests.ps1
@@ -80,4 +80,20 @@ Describe 'Compile-BuildPlan' {
         $plan.TaskMap.ContainsKey('build') | Should -BeTrue
         $plan.TaskMap['build'].DependsOn | Should -Contain 'Clean'
     }
+
+    It 'Should not crash when BuildFile has no directory component (bare filename)' {
+        # Regression: Split-Path 'psakefile.ps1' -Parent returns '' and
+        # Join-Path then throws "Cannot bind argument to parameter 'Path'
+        # because it is an empty string." (issue #368)
+        $buildFile = Join-Path $script:specFolder 'simple_properties_and_tasks_should_pass.ps1'
+        $bareFileName = Split-Path $buildFile -Leaf
+        Push-Location (Split-Path $buildFile -Parent)
+        try {
+            $plan = Get-PsakeBuildPlan -BuildFile $bareFileName
+            $plan.IsValid | Should -BeTrue
+            $plan.CacheDir | Should -Not -BeNullOrEmpty
+        } finally {
+            Pop-Location
+        }
+    }
 }

--- a/tests/Compile-BuildPlan.tests.ps1
+++ b/tests/Compile-BuildPlan.tests.ps1
@@ -16,6 +16,8 @@ BeforeDiscovery {
 Describe 'Compile-BuildPlan' {
     BeforeAll {
         $script:specFolder = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..') -ChildPath 'specs'
+        # PS 5.1 on Windows has no $IsWindows variable; its absence implies Windows.
+        $script:isWindows = !(Test-Path Variable:\IsWindows) -or $IsWindows
     }
     It 'Should compile a valid build plan' {
         $buildFile = Join-Path $script:specFolder 'simple_properties_and_tasks_should_pass.ps1'
@@ -81,7 +83,7 @@ Describe 'Compile-BuildPlan' {
         $plan.TaskMap['build'].DependsOn | Should -Contain 'Clean'
     }
 
-    It 'Should not crash when BuildFile has no directory component (bare filename)' {
+    It 'Should not crash when BuildFile has no directory component (bare filename)' -Skip:(-not $script:isWindows) {
         # Regression: Split-Path 'psakefile.ps1' -Parent returns '' and
         # Join-Path then throws "Cannot bind argument to parameter 'Path'
         # because it is an empty string." (issue #368)

--- a/tests/Compile-BuildPlan.tests.ps1
+++ b/tests/Compile-BuildPlan.tests.ps1
@@ -17,7 +17,7 @@ Describe 'Compile-BuildPlan' {
     BeforeAll {
         $script:specFolder = Join-Path -Path (Join-Path -Path $PSScriptRoot -ChildPath '..') -ChildPath 'specs'
         # PS 5.1 on Windows has no $IsWindows variable; its absence implies Windows.
-        $script:isWindows = !(Test-Path Variable:\IsWindows) -or $IsWindows
+        $script:isWindowsPlatform = !(Test-Path Variable:\IsWindows) -or $IsWindows
     }
     It 'Should compile a valid build plan' {
         $buildFile = Join-Path $script:specFolder 'simple_properties_and_tasks_should_pass.ps1'
@@ -83,7 +83,7 @@ Describe 'Compile-BuildPlan' {
         $plan.TaskMap['build'].DependsOn | Should -Contain 'Clean'
     }
 
-    It 'Should not crash when BuildFile has no directory component (bare filename)' -Skip:(-not $script:isWindows) {
+    It 'Should not crash when BuildFile has no directory component (bare filename)' -Skip:(-not $script:isWindowsPlatform) {
         # Regression: Split-Path 'psakefile.ps1' -Parent returns '' and
         # Join-Path then throws "Cannot bind argument to parameter 'Path'
         # because it is an empty string." (issue #368)

--- a/tests/integration/spec.tests.ps1
+++ b/tests/integration/spec.tests.ps1
@@ -72,6 +72,15 @@ Describe 'PSake specs' {
             throw "Invalid specification syntax. Specs file [$Name] should end with _should_pass or _should_fail."
         }
 
+        # Check if spec requires Windows and skip on non-Windows platforms.
+        # PS 5.1 on Windows has no $IsWindows variable; its absence implies Windows.
+        $isWindowsPlatform = !(Test-Path Variable:\IsWindows) -or $IsWindows
+        $firstLine = Get-Content $FullName -TotalCount 1
+        if ($firstLine -match '# Requires: Windows' -and -not $isWindowsPlatform) {
+            Set-ItResult -Inconclusive -Because "Windows-only spec, skipping on non-Windows."
+            return
+        }
+
         # Check if there is a framework defined in the spec file is installed.
         if (-not (Test-BuildEnvironment -BuildFile $FullName )) {
             Set-ItResult -Inconclusive -Because "Required framework for this spec is not available. Skipping test."


### PR DESCRIPTION
Release 5.0.1 — patch fix for issue #368.

## Fixed

- Crash when `Invoke-psake` or `Get-PsakeBuildPlan` is called with a
  bare build-file name (no directory component), e.g. `psake.cmd
  TaskName` resolving `psakefile.ps1`. `Split-Path` returned an empty
  string, causing `Join-Path` to throw. Now falls back to the current
  working directory. (issue #368)

## Includes

- Bug fix in `Compile-BuildPlan` (9b4633b)
- Regression tests: unit test in `Compile-BuildPlan.tests.ps1` and
  integration spec `cmd_style_task_invocation_should_pass.ps1`
- `# Requires: Windows` spec header convention for platform-gated
  specs (cmd-style invocation is Windows-only)
- Version bump to 5.0.1 in `src/psake.psd1` and `CHANGELOG.md`