### PR TITLE
fix: restore task action output suppressed in 5.0.1 (issue #370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.0.2] - 2026-04-15
+
+### Fixed
+
+- Task action console output was silently suppressed. `Invoke-BuildPlan`
+  used `$null = & $task.Action` (and the same for PreAction, PostAction,
+  and setup/teardown hooks), which discarded the entire pipeline. Output
+  now flows to the host via `Out-Host`, gated so JSON and `-Quiet` modes
+  still stay silent. (issue #370)
+- `Exec` buffered all command output before processing
+  (`$cmdOutput = & $Cmd 2>&1`), preventing real-time display. Replaced
+  with a streaming `ForEach-Object` loop that writes stdout through the
+  pipeline item-by-item while still capturing stderr for error
+  reporting. On failure the error message includes stdout only when
+  output is suppressed, to avoid duplicating already-shown output.
+
 ## [5.0.1] - 2026-04-14
 
 ### Fixed

--- a/specs/task_output_not_suppressed_should_pass.ps1
+++ b/specs/task_output_not_suppressed_should_pass.ps1
@@ -1,0 +1,6 @@
+Task default -Depends Test
+
+Task Test {
+    Write-Output "direct output - should be visible"
+    Exec { Write-Output "via Exec - should also be visible" }
+}

--- a/src/private/Invoke-BuildPlan.ps1
+++ b/src/private/Invoke-BuildPlan.ps1
@@ -52,6 +52,11 @@ function Invoke-BuildPlan {
 
     $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
+    # In JSON and Quiet modes all task output is suppressed; in all other modes
+    # output is routed directly to the host so it does not pollute the pipeline
+    # (the return value of Invoke-BuildPlan must be a PsakeBuildResult only).
+    $suppressOutput = $script:CurrentOutputFormat -in @('JSON', 'Quiet')
+
     try {
         # Inject parameters
         foreach ($key in $Parameters.Keys) {
@@ -84,7 +89,7 @@ function Invoke-BuildPlan {
         $null = . $Module $Initialization
 
         # Run build setup
-        $null = & $CurrentContext.buildSetupScriptBlock
+        if ($suppressOutput) { $null = & $CurrentContext.buildSetupScriptBlock } else { & $CurrentContext.buildSetupScriptBlock | Out-Host }
 
         try {
             # Execute tasks in plan order
@@ -164,10 +169,10 @@ function Invoke-BuildPlan {
                         $CurrentContext.currentTaskName = $task.Name
 
                         try {
-                            $null = & $CurrentContext.taskSetupScriptBlock @($task)
+                            if ($suppressOutput) { $null = & $CurrentContext.taskSetupScriptBlock @($task) } else { & $CurrentContext.taskSetupScriptBlock @($task) | Out-Host }
                             try {
                                 if ($task.PreAction) {
-                                    $null = & $task.PreAction
+                                    if ($suppressOutput) { $null = & $task.PreAction } else { & $task.PreAction | Out-Host }
                                 }
 
                                 if ($CurrentContext.config.taskNameFormat -is [ScriptBlock]) {
@@ -177,10 +182,10 @@ function Invoke-BuildPlan {
                                 }
                                 Write-BuildMessage $taskHeader "heading"
 
-                                $null = & $task.Action
+                                if ($suppressOutput) { $null = & $task.Action } else { & $task.Action | Out-Host }
                             } finally {
                                 if ($task.PostAction) {
-                                    $null = & $task.PostAction
+                                    if ($suppressOutput) { $null = & $task.PostAction } else { & $task.PostAction | Out-Host }
                                 }
                             }
                         } catch {
@@ -191,7 +196,7 @@ function Invoke-BuildPlan {
                             $task.ErrorRecord = $_
                             throw $_
                         } finally {
-                            $null = & $CurrentContext.taskTearDownScriptBlock $task
+                            if ($suppressOutput) { $null = & $CurrentContext.taskTearDownScriptBlock $task } else { & $CurrentContext.taskTearDownScriptBlock $task | Out-Host }
                         }
                     } catch {
                         # Emit a positioned annotation so VS Code's problem matcher can
@@ -276,7 +281,7 @@ function Invoke-BuildPlan {
                 $buildResult.Tasks += $taskResult
             }
         } finally {
-            $null = & $CurrentContext.buildTearDownScriptBlock
+            if ($suppressOutput) { $null = & $CurrentContext.buildTearDownScriptBlock } else { & $CurrentContext.buildTearDownScriptBlock | Out-Host }
         }
 
     } catch {

--- a/src/psake.psd1
+++ b/src/psake.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule           = 'psake.psm1'
-    ModuleVersion        = '5.0.1'
+    ModuleVersion        = '5.0.2'
     GUID                 = 'cfb53216-072f-4a46-8975-ff7e6bda05a5'
     Author               = 'James Kovacs'
     CompanyName          = 'psake'

--- a/src/public/Execute.ps1
+++ b/src/public/Execute.ps1
@@ -111,15 +111,28 @@ function Execute {
                 }
                 Write-BuildMessage ($msgs.exec_standard_output -f $process.StandardOutput.ReadToEnd()) "Default"
             } else {
-                $cmdOutput = & $Cmd 2>&1
-                $stdErr = @($cmdOutput | Where-Object { $_ -is [System.Management.Automation.ErrorRecord] })
-                $stdOut = @($cmdOutput | Where-Object { $_ -isnot [System.Management.Automation.ErrorRecord] })
+                # Stream output in real-time: stdout is passed through the pipeline
+                # so Invoke-BuildPlan can route it to the console; stderr is captured
+                # for error reporting on failure.
+                $stdErr = [System.Collections.ArrayList]@()
+                $stdOut = [System.Collections.ArrayList]@()
+                & $Cmd 2>&1 | ForEach-Object {
+                    if ($_ -is [System.Management.Automation.ErrorRecord]) {
+                        [void]$stdErr.Add($_)
+                    } else {
+                        [void]$stdOut.Add($_)
+                        $_  # stream stdout to pipeline for real-time display
+                    }
+                }
                 if ($global:lastexitcode -ne 0) {
                     $errMsg = "Exec: $($ErrorMessage.Trim()) (exit code: $global:lastexitcode)"
-                    # Include all command output — many tools write
-                    # errors to stdout rather than stderr
+                    # In JSON/Quiet mode stdout was suppressed by the caller, so
+                    # include it in the error message for diagnostic visibility.
+                    # In other modes stdout was already streamed to the console, so
+                    # only include stderr to avoid duplicating the output.
+                    $isOutputSuppressed = $script:CurrentOutputFormat -in @('JSON', 'Quiet')
                     $combinedOutput = @()
-                    if ($stdOut.Count -gt 0) {
+                    if ($isOutputSuppressed -and $stdOut.Count -gt 0) {
                         $combinedOutput += ($stdOut | ForEach-Object { $_.ToString() }) -join [Environment]::NewLine
                     }
                     if ($stdErr.Count -gt 0) {
@@ -147,8 +160,7 @@ function Execute {
                     )
                     $PSCmdlet.ThrowTerminatingError($errorRecord)
                 }
-                # Command succeeded — pass stdout through
-                if ($stdOut.Count -gt 0) { $stdOut }
+                # Command succeeded — stdout was already streamed to the pipeline above
             }
             break
         } catch [Exception] {

--- a/tests/PsakeBuildResult.tests.ps1
+++ b/tests/PsakeBuildResult.tests.ps1
@@ -60,6 +60,16 @@ Describe 'PsakeBuildResult' {
         $result.ErrorRecord | Should -Not -BeNullOrEmpty
     }
 
+    It 'Should return a single PsakeBuildResult (not an array) when task writes to pipeline' {
+        # Regression test for issue #370: task output was polluting Invoke-Psake's
+        # return value, causing $result to be an array instead of a PsakeBuildResult.
+        $buildFile = Join-Path $script:specFolder 'task_output_not_suppressed_should_pass.ps1'
+        $result = Invoke-Psake -BuildFile $buildFile -NoLogo -Quiet
+        $result | Should -Not -BeNullOrEmpty
+        $result.GetType().Name | Should -Be 'PsakeBuildResult'
+        $result.Success | Should -BeTrue
+    }
+
     It 'Should include ErrorRecord on ContinueOnError task results' {
         $buildFile = Join-Path $script:specFolder 'invoketask_with_continueonerror_should_pass.ps1'
         $result = Invoke-Psake -BuildFile $buildFile -NoLogo -Quiet


### PR DESCRIPTION
## 5.0.2

### Fixed

- Task action console output was silently suppressed. `Invoke-BuildPlan` used `$null = & $task.Action` (and the same for PreAction, PostAction, and setup/teardown hooks), which discarded the entire pipeline. Output now flows to the host via `Out-Host`, gated so JSON and `-Quiet` modes still stay silent. (issue #370)
- `Exec` buffered all command output before processing (`$cmdOutput = & $Cmd 2>&1`), preventing real-time display. Replaced with a streaming `ForEach-Object` loop that writes stdout through the pipeline item-by-item while still capturing stderr for error reporting. On failure the error message includes stdout only when output is suppressed, to avoid duplicating already-shown output.

Fixes psake/psake#370