### PR TITLE
docs: improve comment-based help across all public functions

### DIFF
--- a/src/public/Assert.ps1
+++ b/src/public/Assert.ps1
@@ -4,37 +4,44 @@ function Assert {
     Helper function for "Design by Contract" assertion checking.
 
     .DESCRIPTION
-    This is a helper function that makes the code less noisy by eliminating many of the "if" statements that are normally required to verify assumptions in the code.
+    This is a helper function that makes the code less noisy by eliminating many
+    of the "if" statements that are normally required to verify assumptions in
+    the code.
 
     .PARAMETER ConditionToCheck
     The boolean condition to evaluate
 
     .PARAMETER FailureMessage
-    The error message used for the exception if the ConditionToCheck parameter is false
+    The error message used for the exception if the ConditionToCheck parameter
+    is false
 
     .EXAMPLE
-    C:\PS>Assert $false "This always throws an exception"
+    Assert $false "This always throws an exception"
 
     Example of an assertion that will always fail.
 
     .EXAMPLE
-    C:\PS>Assert ( ($i % 2) -eq 0 ) "$i is not an even number"
+    Assert ( ($i % 2) -eq 0 ) "$i is not an even number"
 
-    This exmaple may throw an exception if $i is not an even number
+    This example may throw an exception if $i is not an even number
 
-    Note:
-    It might be necessary to wrap the condition with paranthesis to force PS to evaluate the condition
-    so that a boolean value is calculated and passed into the 'ConditionToCheck' parameter.
+    It might be necessary to wrap the condition with parentheses to force
+    PowerShell to evaluate the condition so that a boolean value is calculated
+    and passed into the 'ConditionToCheck' parameter.
 
-    Example:
-        Assert 1 -eq 2 "1 doesn't equal 2"
+    .EXAMPLE
+    Assert 1 -eq 2 "1 doesn't equal 2"
 
-    PS will pass 1 into the condtionToCheck variable and PS will look for a parameter called "eq" and
-    throw an exception with the following message "A parameter cannot be found that matches parameter name 'eq'"
+    PowerShell will pass 1 into the ConditionToCheck variable and PS will look
+    for a parameter called "eq" and throw an exception with the following
+    message "A parameter cannot be found that matches parameter name 'eq'"
 
-    The solution is to wrap the condition in () so that PS will evaluate it first.
+    The solution is to wrap the condition in () so that PowerShell will evaluate
+    it first.
 
+    ```powershell
     Assert (1 -eq 2) "1 doesn't equal 2"
+    ```
     #>
     [CmdletBinding()]
     param(

--- a/src/public/BuildSetup.ps1
+++ b/src/public/BuildSetup.ps1
@@ -2,30 +2,32 @@ function BuildSetup {
     <#
     .SYNOPSIS
     Adds a scriptblock that will be executed once at the beginning of the build
-    .DESCRIPTION
-    This function will accept a scriptblock that will be executed once at the
-    beginning of the build.
-    .PARAMETER Setup
-    A scriptblock to execute
-    .EXAMPLE
 
+    .DESCRIPTION
+    Runs once before the first task executes. Use this to set up shared
+    state, logging, or environment validation for the whole build.
+
+    .PARAMETER Setup
+    Executed once before any tasks run.
+
+    .EXAMPLE
     Task default -Depends Test
-    Task Test -Depends Compile, Clean {
-    }
-    Task Compile -Depends Clean {
-    }
-    Task Clean {
-    }
+    Task Test -Depends Compile, Clean {}
+    Task Compile -Depends Clean {}
+    Task Clean {}
     BuildSetup {
         "Running 'BuildSetup'"
     }
 
     The script above produces the following output:
+
+    ```
     Running 'BuildSetup'
     Executing task, Clean...
     Executing task, Compile...
     Executing task, Test...
     Build Succeeded
+    ```
     #>
     [CmdletBinding()]
     param(

--- a/src/public/BuildTearDown.ps1
+++ b/src/public/BuildTearDown.ps1
@@ -2,49 +2,53 @@ function BuildTearDown {
     <#
     .SYNOPSIS
     Adds a scriptblock that will be executed once at the end of the build
+
     .DESCRIPTION
-    This function will accept a scriptblock that will be executed once at the
-    end of the build, regardless of success or failure
+    Runs after all tasks complete, even if the build failed. Use this for
+    cleanup, notifications, or post-build reporting.
+
     .PARAMETER Setup
-    A scriptblock to execute
+    Executed after all tasks finish, whether or not the build succeeded.
+
     .EXAMPLE
     Task default -Depends Test
-    Task Test -Depends Compile, Clean {
-    }
-    Task Compile -Depends Clean {
-    }
-    Task Clean {
-    }
+    Task Test -Depends Compile, Clean {}
+    Task Compile -Depends Clean {}
+    Task Clean {}
     BuildTearDown {
         "Running 'BuildTearDown'"
     }
 
     The script above produces the following output:
+
+    ```
     Executing task, Clean...
     Executing task, Compile...
     Executing task, Test...
     Running 'BuildTearDown'
     Build Succeeded
+    ```
     .EXAMPLE
     Task default -Depends Test
     Task Test -Depends Compile, Clean {
         throw "forced error"
     }
-    Task Compile -Depends Clean {
-    }
-    Task Clean {
-    }
+    Task Compile -Depends Clean {}
+    Task Clean {}
     BuildTearDown {
         "Running 'BuildTearDown'"
     }
 
     The script above produces the following output:
+
+    ```
     Executing task, Clean...
     Executing task, Compile...
     Executing task, Test...
     Running 'BuildTearDown'
     forced error
     At line:x char:x ...
+    ```
     #>
     [CmdletBinding()]
     param(

--- a/src/public/Execute.ps1
+++ b/src/public/Execute.ps1
@@ -4,12 +4,8 @@ function Execute {
     Helper function for executing command-line programs.
 
     .DESCRIPTION
-    This is a helper function that runs a scriptblock and checks the PS variable
-    $lastexitcode to see if an error occured.
-
-    If an error is detected then an exception is thrown.
-    This function allows you to run command-line programs without having to
-    explicitly check the $lastexitcode variable.
+    Throws a terminating error if $lastexitcode is non-zero after the
+    command runs, so callers don't need to check it after each invocation.
 
     .PARAMETER Cmd
     The scriptblock to execute. This scriptblock will typically contain the

--- a/src/public/FormatTaskName.ps1
+++ b/src/public/FormatTaskName.ps1
@@ -1,35 +1,34 @@
 function FormatTaskName {
     <#
     .SYNOPSIS
-    This function allows you to change how psake renders the task name during a build.
+    This function allows you to change how psake renders the task name during a
+    build.
 
     .DESCRIPTION
-    This function takes either a string which represents a format string (formats using the -f format operator see "help about_operators") or it can accept a script block that has a single parameter that is the name of the task that will be executed.
+    Useful for adding visual separators or color to task names in the
+    build output. Accepts a -f format string or a scriptblock that
+    receives the task name as its only argument.
 
     .PARAMETER Format
     A format string or a scriptblock to execute
 
     .EXAMPLE
-    A sample build script that uses a format string is shown below:
-
     Task default -depends TaskA, TaskB, TaskC
-
     FormatTaskName "-------- {0} --------"
-
     Task TaskA {
-    "TaskA is executing"
+        "TaskA is executing"
     }
-
     Task TaskB {
-    "TaskB is executing"
+        "TaskB is executing"
+    }
+    Task TaskC {
+        "TaskC is executing"
     }
 
-    Task TaskC {
-    "TaskC is executing"
+    A sample build script that uses a format string. The script above produces
+    the following output:
 
-    -----------
-    The script above produces the following output:
-
+    ```
     -------- TaskA --------
     TaskA is executing
     -------- TaskB --------
@@ -38,32 +37,28 @@ function FormatTaskName {
     TaskC is executing
 
     Build Succeeded!
+    ```
     .EXAMPLE
-    A sample build script that uses a ScriptBlock is shown below:
-
     Task default -depends TaskA, TaskB, TaskC
-
     FormatTaskName {
         param($taskName)
-        write-host "Executing Task: $taskName" -foregroundcolor blue
+        write-host "Executing Task: $taskName" -ForegroundColor blue
     }
-
     Task TaskA {
-    "TaskA is executing"
+        "TaskA is executing"
     }
-
     Task TaskB {
-    "TaskB is executing"
+        "TaskB is executing"
     }
-
     Task TaskC {
-    "TaskC is executing"
+        "TaskC is executing"
     }
 
-    -----------
-    The above example uses the scriptblock parameter to the FormatTaskName function to render each task name in the color blue.
+    A sample build script that uses a ScriptBlock. The above example uses the
+    scriptblock parameter to the FormatTaskName function to render each task
+    name in the color blue.
 
-    Note: the $taskName parameter is arbitrary, it could be named anything.
+    Note: the $taskName parameter name is arbitrary, it could be named anything.
     #>
     [CmdletBinding()]
     param(

--- a/src/public/Framework.ps1
+++ b/src/public/Framework.ps1
@@ -4,16 +4,16 @@ function Framework {
     Sets the version of the .NET framework you want to use during build.
 
     .DESCRIPTION
-    This function will accept a string containing version of the .NET framework
-    to use during build.
-    Possible values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0', '3.0x86',
-    '3.0x64', '3.5', '3.5x86', '3.5x64', '4.0', '4.0x86', '4.0x64', '4.5',
-    '4.5x86', '4.5x64', '4.5.1', '4.5.1x86', '4.5.1x64'.
-    Default is '3.5*', where x86 or x64 will be detected based on the bitness of
-    the PowerShell process.
+    Overrides the psake default framework, determining which MSBuild and
+    runtime directories are used by all tasks in the build.
 
     .PARAMETER Framework
-    Version of the .NET framework to use during build.
+    Framework version string. Append 'x86' or 'x64' to force bitness;
+    otherwise bitness matches the current PowerShell process.
+    Supported values: '1.0', '1.1', '2.0', '2.0x86', '2.0x64', '3.0',
+    '3.0x86', '3.0x64', '3.5', '3.5x86', '3.5x64', '4.0', '4.0x86',
+    '4.0x64', '4.5', '4.5x86', '4.5x64', '4.5.1', '4.5.1x86', '4.5.1x64'.
+    Default is '3.5*' (bitness auto-detected).
 
     .EXAMPLE
     Framework "4.0"
@@ -22,7 +22,7 @@ function Framework {
         msbuild /version
     }
 
-    The script above will output detailed version of msbuid v4
+    Uses MSBuild v4.0 for the build.
     #>
     [CmdletBinding()]
     param(

--- a/src/public/Get-PSakeScriptTasks.ps1
+++ b/src/public/Get-PSakeScriptTasks.ps1
@@ -4,13 +4,14 @@ function Get-PSakeScriptTasks {
     Returns meta data about all the tasks defined in the provided psake script.
 
     .DESCRIPTION
-    Returns meta data about all the tasks defined in the provided psake script.
+    Loads the build file and evaluates task definitions without executing
+    any tasks. Useful for tooling, IDE integrations, and tab completion.
 
     .PARAMETER BuildFile
     The path to the psake build script to read the tasks from.
 
     .EXAMPLE
-    PS C:\>Get-PSakeScriptTasks -BuildFile '.\build.ps1'
+    Get-PSakeScriptTasks -BuildFile '.\build.ps1'
 
     DependsOn        Alias Name    Description
     ---------        ----- ----    -----------

--- a/src/public/Include.ps1
+++ b/src/public/Include.ps1
@@ -5,18 +5,19 @@ function Include {
     current build script's scope
 
     .DESCRIPTION
-    A build script may declare an "includes" function which allows you to define
-    a file containing powershell code to be included and added to the scope of
-    the currently running build script. Code from such file will be executed
-    after code from build script.
+    Included scripts are dot-sourced into the build script's scope after
+    the build file finishes loading. You can call Include more than once.
 
     .PARAMETER Path
-    A string containing the path and name of the powershell file to include
-    (wildcards can be used)
+    Path to the script file(s) to include. Supports wildcards.
 
     .PARAMETER LiteralPath
-    A string containing the path and name of the powershell file to include (no
-    wildcards)
+    Path to the script file to include. No wildcard expansion.
+
+    .INPUTS
+    System.String
+
+    The path(s) to the script file(s) to include in the build.
 
     .EXAMPLE
     Include ".\build_utils.ps1"
@@ -28,9 +29,8 @@ function Include {
     Task Clean {
     }
 
-    The script above includes all the functions and variables defined in the ".\build_utils.ps1" script into the current build script's scope
-
-    Note: You can have more than 1 "Include" function defined in the build script.
+    Includes all functions and variables from build_utils.ps1 in the
+    build script's scope.
 
     .EXAMPLE
     @("File1.ps1","File2.ps1") | Include

--- a/src/public/Invoke-Task.ps1
+++ b/src/public/Invoke-Task.ps1
@@ -4,8 +4,8 @@ function Invoke-Task {
     Executes another task in the current build script.
 
     .DESCRIPTION
-    This is a function that will allow you to invoke a Task from within another
-    Task in the current build script.
+    Use this inside a task's Action when you need to sequence tasks
+    programmatically rather than declaring them with -Depends.
 
     .PARAMETER TaskName
     The name of the task to execute.

--- a/src/public/Invoke-psake.ps1
+++ b/src/public/Invoke-psake.ps1
@@ -20,7 +20,6 @@ function Invoke-Psake {
     A comma-separated list of task names to execute
 
     .PARAMETER Framework
-
     The version of the .NET framework you want to use during build. You can
     append x86 or x64 to force a specific framework. If not specified, x86 or
     x64 will be detected based on the bitness of the PowerShell process.
@@ -54,10 +53,10 @@ function Invoke-Psake {
     Do not display the time report.
 
     .PARAMETER OutputFormat
-    The output format. 'Default' for console output, 'JSON' for JSON to stdout,
-    'GitHubActions' for GitHub Actions workflow annotations (::error::, ::warning::, ::debug::),
-    'Annotated' for colored console output plus annotation lines for errors/warnings (VS Code problem matcher).
-    If not specified, the PSAKE_OUTPUT_FORMAT environment variable is checked as a fallback.
+    Output format. 'Default' for console, 'JSON' for stdout JSON,
+    'GitHubActions' for workflow annotations (::error::, ::warning::,
+    ::debug::), 'Annotated' for console + annotation lines (VS Code
+    problem matcher). Falls back to PSAKE_OUTPUT_FORMAT env variable.
 
     .PARAMETER NoCache
     Bypass task caching. All tasks will execute regardless of cache state.
@@ -74,6 +73,11 @@ function Invoke-Psake {
     via the pipeline. Compile-phase parameters (BuildFile, TaskList, Framework,
     Docs, DetailedDocs, CompileOnly) are ignored when a plan is provided.
     Note: the build file is re-loaded during the execution phase.
+
+    .INPUTS
+    PsakeBuildPlan
+
+    A pre-compiled build plan from Get-PsakeBuildPlan, typically via the pipeline.
 
     .EXAMPLE
     Invoke-psake

--- a/src/public/Properties.ps1
+++ b/src/public/Properties.ps1
@@ -56,27 +56,11 @@ function Properties {
     Variables still work correctly at runtime, but PSScriptAnalyzer cannot detect
     that they will be used in tasks.
     .NOTES
-    This works by defining a script block that is pushed onto the
-    $psake.Context.Peek().properties stack. This allows the properties to be
-    accessed within all tasks in the build script.
-    This means that the variables defined in the script block will be
-    available in the scope of the tasks, but not in the global scope of the
-    build script.
+    Properties scriptblocks are dot-sourced into each task's scope at
+    runtime. Variables are not accessible outside of task scriptblocks.
 
-    PSScriptAnalyzer may warn about variables assigned but not used
-    (PSUseDeclaredVarsMoreThanAssignments) when variables are declared in
-    Properties blocks. This is a false positive - the variables ARE used
-    in tasks when the Properties scriptblock is dot-sourced at runtime.
-
-    To suppress this warning, use script-scoped variables:
-
-    Properties {
-        $script:build_dir = "c:\build"
-        $script:connection_string = "datasource=..."
-    }
-
-    This has identical runtime behavior but satisfies PSScriptAnalyzer's
-    static analysis requirements. See the examples above for more details.
+    PSScriptAnalyzer may flag declared variables as unused — this is a
+    false positive. Use the $script: prefix to suppress it (see examples).
     #>
     [CmdletBinding(DefaultParameterSetName = 'ScriptBlock')]
     param(

--- a/src/public/Task.ps1
+++ b/src/public/Task.ps1
@@ -4,9 +4,8 @@ function Task {
     Defines a build task to be executed by psake
 
     .DESCRIPTION
-    This function creates a 'task' object that will be used by the psake engine
-    to execute a build task.
-    Note: There must be at least one task called 'default' in the build script
+    Defines a named task in the build script. Every script must include
+    at least one task named 'default'.
 
     .PARAMETER Name
     The name of the task
@@ -41,16 +40,10 @@ function Task {
     These tasks will be executed before the current task is executed.
 
     .PARAMETER Definition
-    A hashtable that can be used to define a task using a single parameter
-    instead of using multiple parameters. This is an alternative to the normal
-    syntax of Task 'TaskName' -Action { ... } -Depends 'OtherTask' and allows
-    for a more declarative style of task definition. The hashtable can contain
-    the following keys:
-    - Action
-    - PreAction
-    - PostAction
-    - PreCondition
-    - PostCondition
+    Declarative hashtable alternative to named parameters.
+    Supported keys: Action, PreAction, PostAction, PreCondition,
+    PostCondition, ContinueOnError, Description, Alias,
+    RequiredVariables.
 
     .PARAMETER RequiredVariables
     An array of names of variables that must be set to run this task.
@@ -92,43 +85,8 @@ function Task {
         "Clean"
     }
 
-    The 'default' task is required and should not contain an 'Action' parameter.
-    It uses the 'Depends' parameter to specify that 'Test' is a dependency
-
-    The 'Test' task uses the 'Depends' parameter to specify that 'Compile' and
-    'Clean' are dependencies
-    The 'Compile' task depends on the 'Clean' task.
-
-    Note:
-    The 'Action' parameter is defaulted to the script block following the
-    'Clean' task.
-
-    An equivalent 'Test' task is shown below:
-
-    Task Test -Depends Compile, Clean -Action {
-        $testMessage
-    }
-
-    The output for the above sample build script is shown below:
-
-    Executing task, Clean...
-    Clean
-    Executing task, Compile...
-    Compile
-    Executing task, Test...
-    This is a test
-
-    Build Succeeded!
-
-    ----------------------------------------------------------------------
-    Build Time Report
-    ----------------------------------------------------------------------
-    Name    Duration
-    ----    --------
-    Clean   00:00:00.0065614
-    Compile 00:00:00.0133268
-    Test    00:00:00.0225964
-    Total:  00:00:00.0782496
+    The trailing scriptblock is equivalent to -Action { ... }.
+    The 'default' task must exist and should declare no Action of its own.
     #>
     [CmdletBinding(DefaultParameterSetName = 'Normal')]
     param(

--- a/src/public/TaskSetup.ps1
+++ b/src/public/TaskSetup.ps1
@@ -4,12 +4,12 @@ function TaskSetup {
     Adds a scriptblock that will be executed before each task
 
     .DESCRIPTION
-    This function will accept a scriptblock that will be executed before each task in the build script.
-
-    The scriptblock accepts an optional parameter which describes the Task being setup.
+    Use this for per-task setup that applies across all tasks, such as
+    logging, timing, or environment checks. The scriptblock receives the
+    current [PsakeTask] as an optional argument.
 
     .PARAMETER Setup
-    A scriptblock to execute
+    Receives the current task as an optional [PsakeTask] argument.
 
     .EXAMPLE
     Task default -Depends Test
@@ -25,6 +25,7 @@ function TaskSetup {
 
     The script above produces the following output:
 
+    ```
     Running 'TaskSetup' for task Clean
     Executing task, Clean...
     Running 'TaskSetup' for task Compile
@@ -33,23 +34,20 @@ function TaskSetup {
     Executing task, Test...
 
     Build Succeeded
-
+    ```
     .EXAMPLE
     Task default -Depends Test
-    Task Test -Depends Compile, Clean {
-    }
-    Task Compile -Depends Clean {
-    }
-    Task Clean {
-    }
+    Task Test -Depends Compile, Clean {}
+    Task Compile -Depends Clean {}
+    Task Clean {}
     TaskSetup {
         param($task)
-
         "Running 'TaskSetup' for task $($task.Name)"
     }
 
     The script above produces the following output:
 
+    ```
     Running 'TaskSetup' for task Clean
     Executing task, Clean...
     Running 'TaskSetup' for task Compile
@@ -58,6 +56,7 @@ function TaskSetup {
     Executing task, Test...
 
     Build Succeeded
+    ```
     #>
     [CmdletBinding()]
     param(

--- a/src/public/TaskTearDown.ps1
+++ b/src/public/TaskTearDown.ps1
@@ -5,14 +5,12 @@ function TaskTearDown {
     Adds a scriptblock to the build that will be executed after each task
 
     .DESCRIPTION
-    This function will accept a scriptblock that will be executed after each
-    task in the build script.
-
-    The scriptblock accepts an optional parameter which describes the Task being
-    torn down.
+    Use this for per-task teardown such as logging duration, checking
+    postconditions, or cleaning up temporary state. The completed
+    [PsakeTask] is passed as an optional argument with success/error info.
 
     .PARAMETER TearDown
-    A scriptblock to execute
+    Receives the completed task as an optional [PsakeTask] argument.
 
     .EXAMPLE
     Task default -Depends Test
@@ -27,6 +25,7 @@ function TaskTearDown {
     }
     The script above produces the following output:
 
+    ```
     Executing task, Clean...
     Running 'TaskTearDown' for task Clean
     Executing task, Compile...
@@ -35,18 +34,15 @@ function TaskTearDown {
     Running 'TaskTearDown' for task Test
 
     Build Succeeded
+    ```
 
     .EXAMPLE
     Task default -Depends Test
-    Task Test -Depends Compile, Clean {
-    }
-    Task Compile -Depends Clean {
-    }
-    Task Clean {
-    }
+    Task Test -Depends Compile, Clean {}
+    Task Compile -Depends Clean {}
+    Task Clean {}
     TaskTearDown {
         param($task)
-
         if ($task.Success) {
             "Running 'TaskTearDown' for task $($task.Name) - success!"
         } else {
@@ -56,6 +52,7 @@ function TaskTearDown {
 
     The script above produces the following output:
 
+    ```
     Executing task, Clean...
     Running 'TaskTearDown' for task Clean - success!
     Executing task, Compile...
@@ -64,6 +61,7 @@ function TaskTearDown {
     Running 'TaskTearDown' for task Test - success!
 
     Build Succeeded
+    ```
     #>
     [CmdletBinding()]
     param(

--- a/src/public/Test-BuildEnvironment.ps1
+++ b/src/public/Test-BuildEnvironment.ps1
@@ -41,7 +41,10 @@ function Test-BuildEnvironment {
     and tested. Ignored when -Framework is also supplied.
 
     .OUTPUTS
-    [bool]
+    System.Boolean
+
+    Returns $true if all required framework directories exist;
+    $false otherwise.
 
     .EXAMPLE
     Test-BuildEnvironment -Framework '4.8'

--- a/src/public/Test-PsakeTask.ps1
+++ b/src/public/Test-PsakeTask.ps1
@@ -28,9 +28,8 @@ function Test-PsakeTask {
     injected into the task's scope. The result object contains details about the
     execution, including success status, duration, and any error messages.
     .NOTES
-    This function is intended for testing purposes and does not execute task
-    dependencies or pre/post actions. It directly invokes the specified task's
-    Action scriptblock in isolation.
+    Dependencies, PreAction, and PostAction are skipped — only the
+    task's Action scriptblock is executed.
     #>
     [CmdletBinding()]
     param(


### PR DESCRIPTION
## Summary

- Rewrote `.DESCRIPTION` sections to explain *why/when* to use each function rather than restating the synopsis or describing obvious mechanics
- Fixed `.EXAMPLE` formatting throughout: code-first order, no blank lines within code blocks, consistent ` ``` ` fences around output, blank lines before each CBH section keyword
- Tightened verbose `.PARAMETER` descriptions and relocated misplaced content (e.g. Framework values list moved from `.DESCRIPTION` into `.PARAMETER`)
- Fixed lines exceeding 80 characters (`Invoke-psake` OutputFormat param, `Test-BuildEnvironment` `.OUTPUTS`)
- Added missing `.INPUTS` blocks for `Include` and `Invoke-psake`
- Fixed `.OUTPUTS` for `Test-BuildEnvironment`: `[bool]` → `System.Boolean` with description
- Removed `C:\PS>` / `PS C:\>` prompt prefixes from `Assert` and `Get-PSakeScriptTasks` examples
- Fixed typos: `occured`, `msbuid`, `exmaple`, `paranthesis`, `condtionToCheck`
- Trimmed `Properties` `.NOTES` (20 → 5 lines) and `Task` example description (37 → 2 lines)

## Test plan

- [ ] Run `.\build.ps1 -Task GenerateCommandReference` and confirm no `WARNING:` lines in output
- [ ] Spot-check generated docs on psake.dev for formatting regressions
- [ ] `Get-Help <FunctionName> -Full` for a few functions to verify CBH renders correctly in the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)